### PR TITLE
chore(ci) unbreak  the advisories gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,10 +50,10 @@ jobs:
       - name: Run fmt
         run: cargo +nightly-2026-02-25 fmt --all -- --check
 
-      - name: cargo deny check advisories
+      - name: cargo deny check advisories bans
         uses: EmbarkStudios/cargo-deny-action@v2
         with:
-          command: check advisories
+          command: check advisories bans
 
   test:
     runs-on: ubuntu-24.04

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3021,9 +3021,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.12"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3c0b69cfcb4e1b9f1bf2f53f95f766e4661169728ec61cd3fe5a0166f2d1386"
+checksum = "9f877e75f39e9827ec50a572dd592684ac28c029578726c85f1b2aa6ab807449"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3303,7 +3303,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.12",
+ "h2 0.4.17",
  "http 1.4.0",
  "http-body 1.0.1",
  "httparse",
@@ -6135,7 +6135,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.4.12",
+ "h2 0.4.17",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
@@ -6182,7 +6182,7 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2 0.4.12",
+ "h2 0.4.17",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
@@ -12720,7 +12720,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "flate2",
- "h2 0.4.12",
+ "h2 0.4.17",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",

--- a/deny.toml
+++ b/deny.toml
@@ -77,9 +77,23 @@ ignore = [
     # h2 0.4.x is pinned at 0.4.17, above the 0.4.16 fix, leaving only h2 0.3.27.
     # Its direct parents are hyper 0.14, reqwest 0.11 and tonic 0.9, all reached
     # through the legacy Solana BigTable and download stacks; 0.3.27 is newest on
-    # that line, so there is no local fix. Low severity. This entry also covers any
-    # future 0.4.x below 0.4.16, so re-check the pin when bumping h2.
+    # that line, so there is no local fix. Low severity. cargo-deny has no
+    # version-scoped form for an advisory ignore, so this entry would also excuse a
+    # 0.4.x below 0.4.16 if the lock ever resolved back onto one; the [bans] entry
+    # below is what keeps the fixed 0.4 line enforced.
     "RUSTSEC-2026-0258",
+]
+
+[bans]
+# 191 crates in this graph resolve to more than one version, nearly all of it from
+# the Solana stack, so the duplicate report is noise. This section exists only for
+# the explicit deny list below.
+multiple-versions = "allow"
+deny = [
+    # Guard for the RUSTSEC-2026-0258 ignore above, which is keyed by advisory ID
+    # and so cannot be limited to the one version that needs it. h2 0.3.27 stays
+    # allowed because it has nowhere to go; a vulnerable 0.4.x fails the build.
+    { name = "h2", version = ">=0.4.0, <0.4.16", reason = "RUSTSEC-2026-0258: the 0.4 line must stay at or above the 0.4.16 patch" },
 ]
 
 [licenses]

--- a/deny.toml
+++ b/deny.toml
@@ -65,6 +65,21 @@ ignore = [
     # debug-formatting an Atomic/Shared holding an invalid pointer, which this
     # workspace never does; 0.9.18 is the latest release on the pinned line.
     "RUSTSEC-2026-0204",
+
+    # im 15.1.0 is pulled by solana-runtime 3.1.4, and bitmaps / sized-chunks are
+    # im's own dependencies, so all three arrive through that single root. im is
+    # unmaintained with no successor on the 15.x line; track until the Solana/Agave
+    # runtime stack drops it. Nothing in this workspace uses im directly.
+    "RUSTSEC-2026-0247", # bitmaps
+    "RUSTSEC-2026-0248", # im
+    "RUSTSEC-2026-0251", # sized-chunks
+
+    # h2 0.4.x is pinned at 0.4.17, above the 0.4.16 fix, leaving only h2 0.3.27.
+    # Its direct parents are hyper 0.14, reqwest 0.11 and tonic 0.9, all reached
+    # through the legacy Solana BigTable and download stacks; 0.3.27 is newest on
+    # that line, so there is no local fix. Low severity. This entry also covers any
+    # future 0.4.x below 0.4.16, so re-check the pin when bumping h2.
+    "RUSTSEC-2026-0258",
 ]
 
 [licenses]


### PR DESCRIPTION
`cargo deny check advisories` fails on main with four findings, so the `fmt`
job is red on every PR regardless of its contents.

Three are unmaintained notices with no local upgrade path: im 15.1.0 comes
from solana-runtime 3.1.4, and bitmaps and sized-chunks are im's own
dependencies, so all three arrive through that one root. Ignore them with the
dependency path recorded.

The fourth is a real vulnerability, RUSTSEC-2026-0258, and the lock carried two
affected h2 versions. Fix the one that can move: h2 0.4.x goes to 0.4.17, above
the 0.4.16 patch. What remains is h2 0.3.27, which has three direct parents --
hyper 0.14, reqwest 0.11 and tonic 0.9 -- all reached through the legacy Solana
BigTable and download stacks. It is the newest release on the 0.3 line, so there
is no local fix and it is ignored. Note the ignore also covers any future 0.4.x
that regresses below 0.4.16.

The Cargo.lock change is applied by hand so the diff stays minimal: the h2
package block's version and checksum, plus the four edges that referenced it.
h2 0.4.17 and 0.4.12 have byte-identical dependency lists, so nothing else
needed to move. Running `cargo update` instead also re-pointed unrelated edges
(windows-sys, socket2, tokio-util, syn) onto older copies already present in
the lock, which does not belong in a CI fix. `cargo tree --frozen --offline`
accepts the result, so the lock is complete. Package count is unchanged at 1174.
