### PR TITLE
feat(proc-macro): expose discriminator constants on generated types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- `shipstern-proc-macro`: generated account types and the `Instructions` wrapper now expose `DISCRIMINATOR` and `DISCRIMINATOR_OFFSET` constants, so consumers can build `memcmp` filters and route on discriminators without re-deriving the bytes from the IDL. The pair is a memcmp predicate: the bytes the parser compares at that offset. It is not a payload boundary, because numeric discriminators (for example SPL Governance) are re-read as the first field of the account body, so decoding still goes through `try_unpack`. No constant is emitted where the parser could not honor it: size-only discriminators, zero-length discriminators, fixed-size fields whose declared width disagrees with the decoded default bytes, and instruction names that collide after case folding ([#294](https://github.com/rpcpool/yellowstone-vixen/issues/294)).
+
 ### Fixed
 
 - `yellowstone-vixen-jetstream-source`: populate `Reward::commission_bps` on both reward conversion paths. The field arrived with `yellowstone-grpc-proto` 12.5 and was hardcoded to an empty string, so consumers reading it saw nothing even though `commission` was already forwarded. It is now derived from the whole-percent commission, which is lossless because the source is a `u8` percentage: a 7% commission reports `700`. Salvaged from ([#254](https://github.com/rpcpool/yellowstone-vixen/pull/254) by @the-orex), which is otherwise superseded by the 0.7.0 dependency bumps.

--- a/crates/mock/src/lib.rs
+++ b/crates/mock/src/lib.rs
@@ -417,7 +417,7 @@ macro_rules! run_ix_parse {
 
             // Ignore filtered instructions, but panic on actual errors
             Err(shipstern_core::ParseError::Filtered) => None,
-            Err(e) => panic!("parse error: {e:?}"),
+            Err(_) => panic!("parse error"),
         }
     };
 }

--- a/crates/proc-macro/src/render/account_parser.rs
+++ b/crates/proc-macro/src/render/account_parser.rs
@@ -22,6 +22,40 @@ fn decode_discriminator_bytes(bytes: &codama_nodes::BytesValueNode) -> Vec<u8> {
 }
 
 ///
+/// Build the discriminator constants for a generated account type.
+///
+/// The pair is a memcmp predicate: `DISCRIMINATOR` is exactly what the parser
+/// compares at `DISCRIMINATOR_OFFSET`. It is not a payload boundary. A numeric
+/// discriminator is re-read as the first field of the account body, so callers
+/// must decode through `try_unpack` rather than slicing past it.
+///
+/// Returns `None` for an empty discriminator, which would match every account.
+///
+fn discriminator_consts(
+    ident: &proc_macro2::Ident,
+    bytes: &[u8],
+    offset: usize,
+) -> Option<TokenStream> {
+    if bytes.is_empty() {
+        return None;
+    }
+
+    Some(quote! {
+        impl #ident {
+            /// Discriminator bytes that identify this account type on the wire.
+            ///
+            /// Pairs with [`Self::DISCRIMINATOR_OFFSET`] as a memcmp predicate:
+            /// these bytes appear at that offset in the raw account data. It is
+            /// not a payload boundary. Decode with `try_unpack`.
+            pub const DISCRIMINATOR: &'static [u8] = &[#(#bytes),*];
+
+            /// Byte offset at which [`Self::DISCRIMINATOR`] begins in the account data.
+            pub const DISCRIMINATOR_OFFSET: usize = #offset;
+        }
+    })
+}
+
+///
 /// Build the *account parser* for a program.
 ///
 /// Generates a wrapper struct with a non-Option oneof field and a manual
@@ -108,7 +142,7 @@ pub fn account_parser(
         }
     });
 
-    let account_matches = accounts.iter().filter_map(|account| {
+    let account_entries = accounts.iter().filter_map(|account| {
         let discriminator = match account.discriminators.first() {
             Some(d) => d,
             None => {
@@ -133,7 +167,7 @@ pub fn account_parser(
 
                         let value_u8 = value as u8;
 
-                        quote! {
+                        let arm = quote! {
                             if let Some(discriminator) = data.get(#offset) {
                                 if *discriminator == #value_u8 {
                                     match <#account_ident as ::borsh::BorshDeserialize>::deserialize(&mut &data[..]) {
@@ -146,7 +180,9 @@ pub fn account_parser(
                                     }
                                 }
                             }
-                        }
+                        };
+
+                        (arm, discriminator_consts(&account_ident, &[value_u8], offset))
                     },
 
                     // Byte discriminators are a prefix and are not part of the account struct.
@@ -154,7 +190,7 @@ pub fn account_parser(
                         let discriminator = decode_discriminator_bytes(bytes);
                         let end = offset + discriminator.len();
 
-                        quote! {
+                        let arm = quote! {
                             if let Some(slice) = data.get(#offset..#end) {
                                 if slice == &[#(#discriminator),*] {
                                     match <#account_ident as ::borsh::BorshDeserialize>::deserialize(&mut &data[#end..]) {
@@ -167,7 +203,9 @@ pub fn account_parser(
                                     }
                                 }
                             }
-                        }
+                        };
+
+                        (arm, discriminator_consts(&account_ident, &discriminator, offset))
                     },
 
                     _ => return None,
@@ -224,7 +262,7 @@ pub fn account_parser(
                     quote! { slice == &[#(#discriminator),*] }
                 };
 
-                quote! {
+                let arm = quote! {
                     if let Some(slice) = data.get(#offset..#end) {
                         if #disc_check {
                             match <#account_ident as ::borsh::BorshDeserialize>::deserialize(&mut &data[#end..]) {
@@ -237,14 +275,25 @@ pub fn account_parser(
                             }
                         }
                     }
-                }
+                };
+
+                // The parser compares a `size`-wide slice against the decoded
+                // default bytes, so a length mismatch can never match. Expose no
+                // constant for a discriminator the parser cannot honor.
+                let disc_const = if discriminator.len() == size {
+                    discriminator_consts(&account_ident, &discriminator, offset)
+                } else {
+                    None
+                };
+
+                (arm, disc_const)
             },
 
             // Handle accounts based on size only (e.g the account is 558 Bytes long)
             DiscriminatorNode::Size(node) => {
                 let size = node.size;
 
-                quote! {
+                let arm = quote! {
                     if data.len() == #size {
                         match <#account_ident as ::borsh::BorshDeserialize>::deserialize(&mut &data[..]) {
                             Ok(parsed) => {
@@ -255,10 +304,17 @@ pub fn account_parser(
                             Err(e) => return Err(ParseError::Other(e.into())),
                         }
                     }
-                }
+                };
+
+                (arm, None)
             },
         })
     });
+
+    let (account_matches, account_disc_consts): (Vec<TokenStream>, Vec<Option<TokenStream>>) =
+        account_entries.unzip();
+
+    let account_disc_consts = account_disc_consts.into_iter().flatten();
 
     let (struct_and_mod, proto_impls) = if accounts.is_empty() {
         let empty_struct = if cfg!(feature = "proto") {
@@ -323,6 +379,8 @@ pub fn account_parser(
 
     quote! {
         #struct_and_mod
+
+        #(#account_disc_consts)*
 
         #proto_impls
 

--- a/crates/proc-macro/src/render/instruction_parser.rs
+++ b/crates/proc-macro/src/render/instruction_parser.rs
@@ -12,6 +12,25 @@ pub(crate) enum DiscriminatorKey {
     Size { size: usize },
 }
 
+impl DiscriminatorKey {
+    ///
+    /// On-wire discriminator bytes and the offset they appear at.
+    ///
+    /// Mirrors exactly what the generated match arm compares: numeric
+    /// discriminators are checked as `*d == (value as u8)`, so they narrow to a
+    /// single byte here too.
+    ///
+    /// `None` for size-only discriminators, which have no byte prefix.
+    ///
+    pub(crate) fn to_bytes_offset(&self) -> Option<(Vec<u8>, usize)> {
+        match self {
+            DiscriminatorKey::Constant { offset, value } => Some((vec![*value as u8], *offset)),
+            DiscriminatorKey::Field { offset, bytes } => Some((bytes.clone(), *offset)),
+            DiscriminatorKey::Size { .. } => None,
+        }
+    }
+}
+
 /// Decode discriminator bytes from a codama [`BytesValueNode`](codama_nodes::BytesValueNode).
 fn decode_discriminator_field_bytes(bytes: &codama_nodes::BytesValueNode) -> Vec<u8> {
     match bytes.encoding {
@@ -82,6 +101,26 @@ pub(crate) fn extract_ix_discriminator_key(
     ix: &codama_nodes::InstructionNode,
 ) -> Option<DiscriminatorKey> {
     extract_discriminator_key(&ix.discriminators, |name| resolve_ix_field(ix, name))
+}
+
+///
+/// Width of the byte window the generated match arm compares, when the
+/// discriminator is a fixed-size field.
+///
+/// The arm slices `offset..offset + size` using the *declared* field width but
+/// compares against the *decoded* default bytes, so a disagreement makes the arm
+/// unmatchable. `None` when no width constraint applies (constant-bytes and
+/// numeric discriminators derive their window from the bytes themselves).
+///
+fn ix_discriminator_slice_width(ix: &codama_nodes::InstructionNode) -> Option<usize> {
+    let DiscriminatorNode::Field(node) = ix.discriminators.first()? else {
+        return None;
+    };
+
+    match resolve_ix_field(ix, &node.name)?.r#type {
+        TypeNode::FixedSize(fixed) => Some(fixed.size),
+        _ => None,
+    }
 }
 
 /// Extract a discriminator key for an event (collision detection).
@@ -606,6 +645,85 @@ pub fn instruction_parser(
         .filter_map(|ix| single_instruction_helper_fn(ix, &wrapper_ident))
         .collect();
 
+    // 1b. Per-instruction discriminator constants, exposed on the wrapper type.
+    //
+    // `to_snake_case().to_uppercase()` is not injective over names that differ
+    // only by case outside ASCII: `ä` and `Ä` are distinct instructions with
+    // distinct variants and distinct `parse_*` helpers, yet both fold to `Ä`.
+    // An ambiguous constant is worse than none, so a colliding group is skipped
+    // entirely, the same rule the width and empty-discriminator guards follow.
+    // Skipping keeps this purely additive: such an IDL compiles exactly as it did
+    // before, minus the constants.
+    let const_name_counts = instructions.iter().fold(
+        std::collections::HashMap::<String, usize>::new(),
+        |mut counts, ix| {
+            *counts
+                .entry(crate::utils::to_snake_case(&ix.name).to_uppercase())
+                .or_default() += 1;
+
+            counts
+        },
+    );
+
+    let disc_consts: Vec<TokenStream> = instructions
+        .iter()
+        .filter_map(|ix| {
+            let (bytes, offset) = extract_ix_discriminator_key(ix)?.to_bytes_offset()?;
+
+            if bytes.is_empty() {
+                return None;
+            }
+
+            // Mirror the account-side guard: when the declared field width and the
+            // decoded default bytes disagree the generated arm can never match, so
+            // expose no constant for a discriminator the parser cannot honor.
+            if ix_discriminator_slice_width(ix).is_some_and(|width| width != bytes.len()) {
+                return None;
+            }
+
+            let base = crate::utils::to_snake_case(&ix.name).to_uppercase();
+
+            if const_name_counts.get(&base) != Some(&1) {
+                return None;
+            }
+
+            let disc_ident = format_ident!("{}_DISCRIMINATOR", base);
+            let offset_ident = format_ident!("{}_DISCRIMINATOR_OFFSET", base);
+
+            let disc_doc = format!(
+                "Discriminator bytes that identify the `{}` instruction on the wire.\n\nPairs \
+                 with [`Self::{}`] as a memcmp predicate: these bytes appear at that offset in \
+                 the raw instruction data. It is not a payload boundary.",
+                *ix.name, offset_ident,
+            );
+
+            let offset_doc = format!(
+                "Byte offset at which [`Self::{}`] begins in the instruction data.",
+                disc_ident,
+            );
+
+            Some(quote! {
+                #[doc = #disc_doc]
+                pub const #disc_ident: &'static [u8] = &[#(#bytes),*];
+
+                #[doc = #offset_doc]
+                pub const #offset_ident: usize = #offset;
+            })
+        })
+        .collect();
+
+    // Skip the impl block entirely when no instruction has a byte discriminator
+    // (e.g. every instruction is size-discriminated).
+    let disc_consts_impl = if disc_consts.is_empty() {
+        quote! {}
+    } else {
+        quote! {
+            impl #wrapper_ident {
+                #(#disc_consts)*
+            }
+        }
+    };
+
     // 2. Group instructions by discriminator for collision detection,
     //    then generate match arms per group.
     let mut groups: Vec<(DiscriminatorKey, Vec<&codama_nodes::InstructionNode>)> = Vec::new();
@@ -782,6 +900,8 @@ pub fn instruction_parser(
         //
 
         #(#helper_fns)*
+
+        #disc_consts_impl
 
         ///
         /// Default instruction resolution using discriminator matching.

--- a/tests/idls/constant_bytes_account.json
+++ b/tests/idls/constant_bytes_account.json
@@ -42,6 +42,41 @@
             }
           }
         ]
+      },
+      {
+        "kind": "accountNode",
+        "name": "offsetVault",
+        "data": {
+          "kind": "structTypeNode",
+          "fields": [
+            {
+              "kind": "structFieldTypeNode",
+              "name": "flag",
+              "type": {
+                "kind": "numberTypeNode",
+                "format": "u8",
+                "endian": "le"
+              }
+            }
+          ]
+        },
+        "discriminators": [
+          {
+            "kind": "constantDiscriminatorNode",
+            "offset": 8,
+            "constant": {
+              "kind": "constantValueNode",
+              "type": {
+                "kind": "bytesTypeNode"
+              },
+              "value": {
+                "kind": "bytesValueNode",
+                "data": "beef",
+                "encoding": "base16"
+              }
+            }
+          }
+        ]
       }
     ],
     "instructions": [],

--- a/tests/idls/discriminator_guards.json
+++ b/tests/idls/discriminator_guards.json
@@ -1,0 +1,124 @@
+{
+  "kind": "rootNode",
+  "standard": "codama",
+  "version": "1.6.0",
+  "program": {
+    "kind": "programNode",
+    "name": "discriminatorGuards",
+    "publicKey": "11111111111111111111111111111111",
+    "version": "0.1.0",
+    "accounts": [
+      {
+        "kind": "accountNode",
+        "name": "sizedOnly",
+        "size": 9,
+        "data": {
+          "kind": "structTypeNode",
+          "fields": [
+            {
+              "kind": "structFieldTypeNode",
+              "name": "amount",
+              "type": { "kind": "numberTypeNode", "format": "u64", "endian": "le" }
+            },
+            {
+              "kind": "structFieldTypeNode",
+              "name": "flag",
+              "type": { "kind": "numberTypeNode", "format": "u8", "endian": "le" }
+            }
+          ]
+        },
+        "discriminators": [{ "kind": "sizeDiscriminatorNode", "size": 9 }]
+      },
+      {
+        "kind": "accountNode",
+        "name": "emptyDiscriminator",
+        "data": {
+          "kind": "structTypeNode",
+          "fields": [
+            {
+              "kind": "structFieldTypeNode",
+              "name": "discriminator",
+              "defaultValueStrategy": "omitted",
+              "type": { "kind": "fixedSizeTypeNode", "size": 0, "type": { "kind": "bytesTypeNode" } },
+              "defaultValue": { "kind": "bytesValueNode", "data": "", "encoding": "base16" }
+            },
+            {
+              "kind": "structFieldTypeNode",
+              "name": "flag",
+              "type": { "kind": "numberTypeNode", "format": "u8", "endian": "le" }
+            }
+          ]
+        },
+        "discriminators": [
+          { "kind": "fieldDiscriminatorNode", "name": "discriminator", "offset": 0 }
+        ]
+      },
+      {
+        "kind": "accountNode",
+        "name": "widthMismatch",
+        "data": {
+          "kind": "structTypeNode",
+          "fields": [
+            {
+              "kind": "structFieldTypeNode",
+              "name": "discriminator",
+              "defaultValueStrategy": "omitted",
+              "type": { "kind": "fixedSizeTypeNode", "size": 8, "type": { "kind": "bytesTypeNode" } },
+              "defaultValue": { "kind": "bytesValueNode", "data": "aabbccdd", "encoding": "base16" }
+            },
+            {
+              "kind": "structFieldTypeNode",
+              "name": "flag",
+              "type": { "kind": "numberTypeNode", "format": "u8", "endian": "le" }
+            }
+          ]
+        },
+        "discriminators": [
+          { "kind": "fieldDiscriminatorNode", "name": "discriminator", "offset": 0 }
+        ]
+      }
+    ],
+    "instructions": [
+      {
+        "kind": "instructionNode",
+        "name": "widthMismatchIx",
+        "accounts": [],
+        "arguments": [
+          {
+            "kind": "instructionArgumentNode",
+            "name": "discriminator",
+            "defaultValueStrategy": "omitted",
+            "docs": [],
+            "type": { "kind": "fixedSizeTypeNode", "size": 8, "type": { "kind": "bytesTypeNode" } },
+            "defaultValue": { "kind": "bytesValueNode", "data": "aabbccdd", "encoding": "base16" }
+          }
+        ],
+        "discriminators": [
+          { "kind": "fieldDiscriminatorNode", "name": "discriminator", "offset": 0 }
+        ]
+      },
+      {
+        "kind": "instructionNode",
+        "name": "wellFormedIx",
+        "accounts": [],
+        "arguments": [
+          {
+            "kind": "instructionArgumentNode",
+            "name": "discriminator",
+            "defaultValueStrategy": "omitted",
+            "docs": [],
+            "type": { "kind": "fixedSizeTypeNode", "size": 4, "type": { "kind": "bytesTypeNode" } },
+            "defaultValue": { "kind": "bytesValueNode", "data": "11223344", "encoding": "base16" }
+          }
+        ],
+        "discriminators": [
+          { "kind": "fieldDiscriminatorNode", "name": "discriminator", "offset": 0 }
+        ]
+      }
+    ],
+    "definedTypes": [],
+    "errors": [],
+    "constants": []
+  },
+  "additionalPrograms": []
+}

--- a/tests/idls/size_only_instructions.json
+++ b/tests/idls/size_only_instructions.json
@@ -1,0 +1,32 @@
+{
+  "kind": "rootNode",
+  "standard": "codama",
+  "version": "1.6.0",
+  "program": {
+    "kind": "programNode",
+    "name": "sizeOnlyInstructions",
+    "publicKey": "11111111111111111111111111111111",
+    "version": "0.1.0",
+    "accounts": [],
+    "instructions": [
+      {
+        "kind": "instructionNode",
+        "name": "onlySized",
+        "accounts": [],
+        "arguments": [
+          {
+            "kind": "instructionArgumentNode",
+            "name": "amount",
+            "docs": [],
+            "type": { "kind": "numberTypeNode", "format": "u32", "endian": "le" }
+          }
+        ],
+        "discriminators": [{ "kind": "sizeDiscriminatorNode", "size": 4 }]
+      }
+    ],
+    "definedTypes": [],
+    "errors": [],
+    "constants": []
+  },
+  "additionalPrograms": []
+}

--- a/tests/idls/unicode_collision.json
+++ b/tests/idls/unicode_collision.json
@@ -1,0 +1,82 @@
+{
+  "kind": "rootNode",
+  "standard": "codama",
+  "version": "1.6.0",
+  "program": {
+    "kind": "programNode",
+    "name": "unicodeCollision",
+    "publicKey": "11111111111111111111111111111111",
+    "version": "0.1.0",
+    "accounts": [],
+    "instructions": [
+      {
+        "kind": "instructionNode",
+        "name": "ä",
+        "accounts": [],
+        "arguments": [
+          {
+            "kind": "instructionArgumentNode",
+            "name": "discriminator",
+            "defaultValueStrategy": "omitted",
+            "docs": [],
+            "type": {
+              "kind": "fixedSizeTypeNode",
+              "size": 4,
+              "type": {
+                "kind": "bytesTypeNode"
+              }
+            },
+            "defaultValue": {
+              "kind": "bytesValueNode",
+              "data": "11223344",
+              "encoding": "base16"
+            }
+          }
+        ],
+        "discriminators": [
+          {
+            "kind": "fieldDiscriminatorNode",
+            "name": "discriminator",
+            "offset": 0
+          }
+        ]
+      },
+      {
+        "kind": "instructionNode",
+        "name": "Ä",
+        "accounts": [],
+        "arguments": [
+          {
+            "kind": "instructionArgumentNode",
+            "name": "discriminator",
+            "defaultValueStrategy": "omitted",
+            "docs": [],
+            "type": {
+              "kind": "fixedSizeTypeNode",
+              "size": 4,
+              "type": {
+                "kind": "bytesTypeNode"
+              }
+            },
+            "defaultValue": {
+              "kind": "bytesValueNode",
+              "data": "55667788",
+              "encoding": "base16"
+            }
+          }
+        ],
+        "discriminators": [
+          {
+            "kind": "fieldDiscriminatorNode",
+            "name": "discriminator",
+            "offset": 0
+          }
+        ]
+      }
+    ],
+    "definedTypes": [],
+    "errors": [],
+    "constants": []
+  },
+  "additionalPrograms": []
+}

--- a/tests/proc-macro/tests/constant_bytes_account.rs
+++ b/tests/proc-macro/tests/constant_bytes_account.rs
@@ -10,7 +10,10 @@ fn parses_account_after_byte_constant_discriminator() {
     let parsed = constant_bytes_account::ConstantBytesAccountAccount::try_unpack(&data)
         .expect("byte-valued constant discriminator should match");
 
-    let constant_bytes_account::account::Account::Vault(vault) = parsed.account;
+    let constant_bytes_account::account::Account::Vault(vault) = parsed.account else {
+        panic!("expected Vault");
+    };
+
     assert_eq!(vault.amount, 42);
 }
 
@@ -25,4 +28,74 @@ fn rejects_an_unknown_byte_constant_discriminator() {
 #[test]
 fn reports_a_truncated_matching_account() {
     assert!(constant_bytes_account::ConstantBytesAccountAccount::try_unpack(&[1, 42]).is_err());
+}
+
+#[test]
+fn exposes_the_byte_constant_discriminator() {
+    assert_eq!(
+        constant_bytes_account::Vault::DISCRIMINATOR,
+        [0x01_u8].as_slice()
+    );
+    assert_eq!(constant_bytes_account::Vault::DISCRIMINATOR_OFFSET, 0);
+}
+
+#[test]
+fn exposes_a_discriminator_at_a_nonzero_offset() {
+    assert_eq!(
+        constant_bytes_account::OffsetVault::DISCRIMINATOR,
+        [0xbe_u8, 0xef].as_slice()
+    );
+    assert_eq!(constant_bytes_account::OffsetVault::DISCRIMINATOR_OFFSET, 8);
+}
+
+///
+/// Build the on-wire buffer straight from the constants and confirm the parser
+/// picks that variant: `prefix ++ DISCRIMINATOR ++ borsh body`.
+///
+/// This is what guards the emit rule: a constant exists only for a
+/// discriminator the parser can actually match on.
+///
+#[test]
+fn round_trips_a_discriminator_at_a_nonzero_offset() {
+    let mut data = vec![0_u8; constant_bytes_account::OffsetVault::DISCRIMINATOR_OFFSET];
+
+    data.extend_from_slice(constant_bytes_account::OffsetVault::DISCRIMINATOR);
+    data.push(7);
+
+    let parsed = constant_bytes_account::ConstantBytesAccountAccount::try_unpack(&data)
+        .expect("discriminator built from the constants should match");
+
+    let constant_bytes_account::account::Account::OffsetVault(vault) = parsed.account else {
+        panic!("expected OffsetVault");
+    };
+
+    assert_eq!(vault.flag, 7);
+}
+
+///
+/// The two accounts must not both match one buffer. Otherwise the match order,
+/// not the constant, decides the result and the round-trip proves nothing.
+///
+#[test]
+fn the_two_discriminators_do_not_overlap() {
+    let mut vault_data = vec![1];
+    vault_data.extend_from_slice(&42_u64.to_le_bytes());
+
+    assert!(vault_data
+        .get(
+            constant_bytes_account::OffsetVault::DISCRIMINATOR_OFFSET
+                ..constant_bytes_account::OffsetVault::DISCRIMINATOR_OFFSET
+                    + constant_bytes_account::OffsetVault::DISCRIMINATOR.len()
+        )
+        .is_none_or(|slice| slice != constant_bytes_account::OffsetVault::DISCRIMINATOR));
+
+    let mut offset_data = vec![0_u8; constant_bytes_account::OffsetVault::DISCRIMINATOR_OFFSET];
+
+    offset_data.extend_from_slice(constant_bytes_account::OffsetVault::DISCRIMINATOR);
+    offset_data.push(7);
+
+    assert_ne!(
+        &offset_data[..constant_bytes_account::Vault::DISCRIMINATOR.len()],
+        constant_bytes_account::Vault::DISCRIMINATOR
+    );
 }

--- a/tests/proc-macro/tests/discriminator_guards.rs
+++ b/tests/proc-macro/tests/discriminator_guards.rs
@@ -1,0 +1,54 @@
+use shipstern_proc_macro::include_shipstern_parser;
+
+include_shipstern_parser!("../idls/discriminator_guards.json");
+
+///
+/// A well-formed fixed-size field discriminator: declared width and decoded
+/// default bytes agree, so the constant is emitted and the matcher honors it.
+///
+#[test]
+fn well_formed_ix_const_is_matchable() {
+    let disc = discriminator_guards::Instructions::WELL_FORMED_IX_DISCRIMINATOR;
+    let offset = discriminator_guards::Instructions::WELL_FORMED_IX_DISCRIMINATOR_OFFSET;
+
+    let mut data = vec![0_u8; offset];
+
+    data.extend_from_slice(disc);
+
+    let path = shipstern_core::instruction::Path::new_single(0);
+
+    assert!(!matches!(
+        discriminator_guards::resolve_instruction_default(&[], &data, &path),
+        Err(shipstern_core::ParseError::DiscriminatorNotFound(_))
+    ));
+}
+
+///
+/// `widthMismatchIx` declares `fixedSize: 8` but a 4-byte default, so its match
+/// arm slices `data[0..8]` and compares against 4 bytes, so it can never match.
+/// No constant is emitted for it; referencing
+/// `Instructions::WIDTH_MISMATCH_IX_DISCRIMINATOR` here would fail to compile.
+///
+/// The same holds for the three accounts in this IDL: `sizedOnly`
+/// (size discriminator), `emptyDiscriminator` (zero-length, matches anything),
+/// and `widthMismatch` (8-byte field, 4-byte default). Absence is enforced at
+/// compile time, so this test only pins the behavior that is observable: that
+/// the parser still works for the accounts it can match.
+///
+#[test]
+fn guarded_accounts_still_parse() {
+    // sizedOnly: 9 bytes total (u64 + u8), matched purely on length.
+    let mut data = 7_u64.to_le_bytes().to_vec();
+
+    data.push(1);
+
+    let parsed = discriminator_guards::DiscriminatorGuardsAccount::try_unpack(&data)
+        .expect("size discriminator should match");
+
+    let discriminator_guards::account::Account::SizedOnly(sized) = parsed.account else {
+        panic!("expected SizedOnly");
+    };
+
+    assert_eq!(sized.amount, 7);
+    assert_eq!(sized.flag, 1);
+}

--- a/tests/proc-macro/tests/dynamic_bonding_curve.rs
+++ b/tests/proc-macro/tests/dynamic_bonding_curve.rs
@@ -25,3 +25,22 @@ fn check_json_serialization() {
     let _: dynamic_bonding_curve::InitializePoolParameters =
         serde_json::from_str(&json_str).expect("failed to json deserialize");
 }
+
+///
+/// Anchor-style field discriminator: an 8-byte sighash stripped before the
+/// account body is deserialized.
+///
+#[test]
+fn exposes_account_discriminators() {
+    assert_eq!(
+        dynamic_bonding_curve::VirtualPool::DISCRIMINATOR,
+        hex::decode("d5e005d16245775c").unwrap().as_slice()
+    );
+    assert_eq!(dynamic_bonding_curve::VirtualPool::DISCRIMINATOR_OFFSET, 0);
+
+    assert_eq!(
+        dynamic_bonding_curve::Config::DISCRIMINATOR,
+        hex::decode("9b0caae01efacc82").unwrap().as_slice()
+    );
+    assert_eq!(dynamic_bonding_curve::Config::DISCRIMINATOR_OFFSET, 0);
+}

--- a/tests/proc-macro/tests/pump_fun.rs
+++ b/tests/proc-macro/tests/pump_fun.rs
@@ -119,3 +119,267 @@ fn check_json_serialization() {
     let _: pump_fun::instruction::Buy =
         serde_json::from_str(&json_str).expect("failed to json deserialize");
 }
+
+#[test]
+fn exposes_account_discriminators() {
+    assert_eq!(
+        pump_fun::BondingCurve::DISCRIMINATOR,
+        hex::decode("17b7f83760d8ac60").unwrap().as_slice()
+    );
+    assert_eq!(pump_fun::BondingCurve::DISCRIMINATOR_OFFSET, 0);
+}
+
+///
+/// Instruction variants are not types, so their discriminators hang on the
+/// `Instructions` wrapper rather than on a per-variant impl.
+///
+#[test]
+fn exposes_instruction_discriminators() {
+    assert_eq!(
+        pump_fun::Instructions::BUY_DISCRIMINATOR,
+        hex::decode("66063d1201daebea").unwrap().as_slice()
+    );
+    assert_eq!(pump_fun::Instructions::BUY_DISCRIMINATOR_OFFSET, 0);
+
+    assert_eq!(
+        pump_fun::Instructions::ADMIN_SET_CREATOR_DISCRIMINATOR,
+        hex::decode("4519ab8e39ef0d04").unwrap().as_slice()
+    );
+}
+
+///
+/// Every emitted instruction constant must be recognised by the matcher.
+///
+/// The constant is built by `extract_ix_discriminator_key` + `to_bytes_offset`,
+/// while the parser matches through `extract_discriminator_info`, two separate
+/// decode paths. Driving `resolve_instruction_default` with a buffer built from
+/// each constant proves they agree: a mismatch surfaces as
+/// `DiscriminatorNotFound`. Argument deserialization is expected to fail on
+/// these synthetic buffers; only the discriminator verdict is asserted.
+///
+#[test]
+fn every_instruction_const_is_recognised_by_the_matcher() {
+    let all: &[(&[u8], usize, &str)] = &[
+        (
+            pump_fun::Instructions::ADMIN_SET_CREATOR_DISCRIMINATOR,
+            pump_fun::Instructions::ADMIN_SET_CREATOR_DISCRIMINATOR_OFFSET,
+            "ADMIN_SET_CREATOR",
+        ),
+        (
+            pump_fun::Instructions::ADMIN_SET_IDL_AUTHORITY_DISCRIMINATOR,
+            pump_fun::Instructions::ADMIN_SET_IDL_AUTHORITY_DISCRIMINATOR_OFFSET,
+            "ADMIN_SET_IDL_AUTHORITY",
+        ),
+        (
+            pump_fun::Instructions::ADMIN_UPDATE_TOKEN_INCENTIVES_DISCRIMINATOR,
+            pump_fun::Instructions::ADMIN_UPDATE_TOKEN_INCENTIVES_DISCRIMINATOR_OFFSET,
+            "ADMIN_UPDATE_TOKEN_INCENTIVES",
+        ),
+        (
+            pump_fun::Instructions::BUY_DISCRIMINATOR,
+            pump_fun::Instructions::BUY_DISCRIMINATOR_OFFSET,
+            "BUY",
+        ),
+        (
+            pump_fun::Instructions::BUY_EXACT_SOL_IN_DISCRIMINATOR,
+            pump_fun::Instructions::BUY_EXACT_SOL_IN_DISCRIMINATOR_OFFSET,
+            "BUY_EXACT_SOL_IN",
+        ),
+        (
+            pump_fun::Instructions::CLAIM_CASHBACK_DISCRIMINATOR,
+            pump_fun::Instructions::CLAIM_CASHBACK_DISCRIMINATOR_OFFSET,
+            "CLAIM_CASHBACK",
+        ),
+        (
+            pump_fun::Instructions::CLAIM_TOKEN_INCENTIVES_DISCRIMINATOR,
+            pump_fun::Instructions::CLAIM_TOKEN_INCENTIVES_DISCRIMINATOR_OFFSET,
+            "CLAIM_TOKEN_INCENTIVES",
+        ),
+        (
+            pump_fun::Instructions::CLOSE_USER_VOLUME_ACCUMULATOR_DISCRIMINATOR,
+            pump_fun::Instructions::CLOSE_USER_VOLUME_ACCUMULATOR_DISCRIMINATOR_OFFSET,
+            "CLOSE_USER_VOLUME_ACCUMULATOR",
+        ),
+        (
+            pump_fun::Instructions::COLLECT_CREATOR_FEE_DISCRIMINATOR,
+            pump_fun::Instructions::COLLECT_CREATOR_FEE_DISCRIMINATOR_OFFSET,
+            "COLLECT_CREATOR_FEE",
+        ),
+        (
+            pump_fun::Instructions::CREATE_DISCRIMINATOR,
+            pump_fun::Instructions::CREATE_DISCRIMINATOR_OFFSET,
+            "CREATE",
+        ),
+        (
+            pump_fun::Instructions::CREATE_V2_DISCRIMINATOR,
+            pump_fun::Instructions::CREATE_V2_DISCRIMINATOR_OFFSET,
+            "CREATE_V2",
+        ),
+        (
+            pump_fun::Instructions::DISTRIBUTE_CREATOR_FEES_DISCRIMINATOR,
+            pump_fun::Instructions::DISTRIBUTE_CREATOR_FEES_DISCRIMINATOR_OFFSET,
+            "DISTRIBUTE_CREATOR_FEES",
+        ),
+        (
+            pump_fun::Instructions::EXTEND_ACCOUNT_DISCRIMINATOR,
+            pump_fun::Instructions::EXTEND_ACCOUNT_DISCRIMINATOR_OFFSET,
+            "EXTEND_ACCOUNT",
+        ),
+        (
+            pump_fun::Instructions::GET_MINIMUM_DISTRIBUTABLE_FEE_DISCRIMINATOR,
+            pump_fun::Instructions::GET_MINIMUM_DISTRIBUTABLE_FEE_DISCRIMINATOR_OFFSET,
+            "GET_MINIMUM_DISTRIBUTABLE_FEE",
+        ),
+        (
+            pump_fun::Instructions::INIT_USER_VOLUME_ACCUMULATOR_DISCRIMINATOR,
+            pump_fun::Instructions::INIT_USER_VOLUME_ACCUMULATOR_DISCRIMINATOR_OFFSET,
+            "INIT_USER_VOLUME_ACCUMULATOR",
+        ),
+        (
+            pump_fun::Instructions::INITIALIZE_DISCRIMINATOR,
+            pump_fun::Instructions::INITIALIZE_DISCRIMINATOR_OFFSET,
+            "INITIALIZE",
+        ),
+        (
+            pump_fun::Instructions::MIGRATE_DISCRIMINATOR,
+            pump_fun::Instructions::MIGRATE_DISCRIMINATOR_OFFSET,
+            "MIGRATE",
+        ),
+        (
+            pump_fun::Instructions::MIGRATE_BONDING_CURVE_CREATOR_DISCRIMINATOR,
+            pump_fun::Instructions::MIGRATE_BONDING_CURVE_CREATOR_DISCRIMINATOR_OFFSET,
+            "MIGRATE_BONDING_CURVE_CREATOR",
+        ),
+        (
+            pump_fun::Instructions::SELL_DISCRIMINATOR,
+            pump_fun::Instructions::SELL_DISCRIMINATOR_OFFSET,
+            "SELL",
+        ),
+        (
+            pump_fun::Instructions::SET_CREATOR_DISCRIMINATOR,
+            pump_fun::Instructions::SET_CREATOR_DISCRIMINATOR_OFFSET,
+            "SET_CREATOR",
+        ),
+        (
+            pump_fun::Instructions::SET_MAYHEM_VIRTUAL_PARAMS_DISCRIMINATOR,
+            pump_fun::Instructions::SET_MAYHEM_VIRTUAL_PARAMS_DISCRIMINATOR_OFFSET,
+            "SET_MAYHEM_VIRTUAL_PARAMS",
+        ),
+        (
+            pump_fun::Instructions::SET_METAPLEX_CREATOR_DISCRIMINATOR,
+            pump_fun::Instructions::SET_METAPLEX_CREATOR_DISCRIMINATOR_OFFSET,
+            "SET_METAPLEX_CREATOR",
+        ),
+        (
+            pump_fun::Instructions::SET_PARAMS_DISCRIMINATOR,
+            pump_fun::Instructions::SET_PARAMS_DISCRIMINATOR_OFFSET,
+            "SET_PARAMS",
+        ),
+        (
+            pump_fun::Instructions::SET_RESERVED_FEE_RECIPIENTS_DISCRIMINATOR,
+            pump_fun::Instructions::SET_RESERVED_FEE_RECIPIENTS_DISCRIMINATOR_OFFSET,
+            "SET_RESERVED_FEE_RECIPIENTS",
+        ),
+        (
+            pump_fun::Instructions::SYNC_USER_VOLUME_ACCUMULATOR_DISCRIMINATOR,
+            pump_fun::Instructions::SYNC_USER_VOLUME_ACCUMULATOR_DISCRIMINATOR_OFFSET,
+            "SYNC_USER_VOLUME_ACCUMULATOR",
+        ),
+        (
+            pump_fun::Instructions::TOGGLE_CASHBACK_ENABLED_DISCRIMINATOR,
+            pump_fun::Instructions::TOGGLE_CASHBACK_ENABLED_DISCRIMINATOR_OFFSET,
+            "TOGGLE_CASHBACK_ENABLED",
+        ),
+        (
+            pump_fun::Instructions::TOGGLE_CREATE_V2_DISCRIMINATOR,
+            pump_fun::Instructions::TOGGLE_CREATE_V2_DISCRIMINATOR_OFFSET,
+            "TOGGLE_CREATE_V2",
+        ),
+        (
+            pump_fun::Instructions::TOGGLE_MAYHEM_MODE_DISCRIMINATOR,
+            pump_fun::Instructions::TOGGLE_MAYHEM_MODE_DISCRIMINATOR_OFFSET,
+            "TOGGLE_MAYHEM_MODE",
+        ),
+        (
+            pump_fun::Instructions::UPDATE_GLOBAL_AUTHORITY_DISCRIMINATOR,
+            pump_fun::Instructions::UPDATE_GLOBAL_AUTHORITY_DISCRIMINATOR_OFFSET,
+            "UPDATE_GLOBAL_AUTHORITY",
+        ),
+    ];
+
+    assert_eq!(
+        all.len(),
+        29,
+        "every pump_fun instruction should expose a constant"
+    );
+
+    for (disc, offset, name) in all {
+        let mut data = vec![0_u8; *offset];
+
+        data.extend_from_slice(disc);
+
+        let path = shipstern_core::instruction::Path::new_single(0);
+
+        if let Err(shipstern_core::ParseError::DiscriminatorNotFound(msg)) =
+            pump_fun::resolve_instruction_default(&[], &data, &path)
+        {
+            panic!("{name}: constant is not recognised by the matcher ({msg})");
+        }
+    }
+}
+
+///
+/// Tie the constant to real on-wire bytes, not just to the matcher.
+///
+/// For the instruction the matcher resolves as `Buy`, the bytes actually present
+/// in the mainnet transaction at `BUY_DISCRIMINATOR_OFFSET` must equal
+/// `BUY_DISCRIMINATOR`.
+///
+#[tokio::test]
+async fn instruction_const_matches_real_mainnet_bytes() {
+    let parser = pump_fun::InstructionParser;
+
+    let fixture = match shipstern_mock::load_fixture(
+        "3tkxRjNDfth6NxXpYbbLKmPkPYyAD4jjXfNnDCYtCKSPN2zSpJXT29reowKtFKz1puY1fHmBFVAskkK2A7o8cZgJ",
+        &parser,
+    )
+    .await
+    .unwrap()
+    {
+        shipstern_mock::FixtureData::Instructions(fixture) => fixture,
+        other => panic!("expected an instruction fixture, got {other:?}"),
+    };
+
+    let mut checked = 0_usize;
+
+    for raw in &fixture.instructions {
+        let update: shipstern_core::instruction::InstructionUpdate = raw.into();
+
+        if *update.program != pump_fun::PROGRAM_ID {
+            continue;
+        }
+
+        let Ok(parsed) =
+            pump_fun::resolve_instruction_default(&update.accounts, &update.data, &update.path)
+        else {
+            continue;
+        };
+
+        let pump_fun::instruction::Instruction::Buy { .. } = &parsed.instruction else {
+            continue;
+        };
+
+        let offset = pump_fun::Instructions::BUY_DISCRIMINATOR_OFFSET;
+        let disc = pump_fun::Instructions::BUY_DISCRIMINATOR;
+
+        assert_eq!(
+            &update.data[offset..offset + disc.len()],
+            disc,
+            "on-wire bytes disagree with BUY_DISCRIMINATOR"
+        );
+
+        checked += 1;
+    }
+
+    assert_eq!(checked, 1, "expected exactly one Buy in the fixture");
+}

--- a/tests/proc-macro/tests/pump_fun.rs
+++ b/tests/proc-macro/tests/pump_fun.rs
@@ -347,7 +347,7 @@ async fn instruction_const_matches_real_mainnet_bytes() {
     .unwrap()
     {
         shipstern_mock::FixtureData::Instructions(fixture) => fixture,
-        other => panic!("expected an instruction fixture, got {other:?}"),
+        _ => panic!("expected an instruction fixture"),
     };
 
     let mut checked = 0_usize;

--- a/tests/proc-macro/tests/size_only_instructions.rs
+++ b/tests/proc-macro/tests/size_only_instructions.rs
@@ -1,0 +1,22 @@
+use shipstern_proc_macro::include_shipstern_parser;
+
+include_shipstern_parser!("../idls/size_only_instructions.json");
+
+///
+/// Every instruction is size-discriminated, so no constant is emitted and the
+/// `impl Instructions` block is skipped entirely. Referencing any
+/// `*_DISCRIMINATOR` on it would fail to compile; the parser still works.
+///
+#[test]
+fn size_only_instructions_emit_no_consts() {
+    let path = shipstern_core::instruction::Path::new_single(0);
+
+    let parsed =
+        size_only_instructions::resolve_instruction_default(&[], &7_u32.to_le_bytes(), &path)
+            .expect("size discriminator should match");
+
+    let size_only_instructions::instruction::Instruction::OnlySized { args, .. } =
+        parsed.instruction;
+
+    assert_eq!(args.amount, 7);
+}

--- a/tests/proc-macro/tests/spl_governance.rs
+++ b/tests/proc-macro/tests/spl_governance.rs
@@ -281,3 +281,24 @@ fn check_json_serialization() {
     let _: spl_governance::SetRealmAuthorityAction =
         serde_json::from_str(&json_str).expect("failed to json deserialize");
 }
+
+///
+/// Numeric constant discriminators, the one branch where the discriminator byte
+/// is *not* stripped: the parser deserializes from `data[..]`, so byte 0 is
+/// re-read as the `account_type` borsh enum tag (16 = RealmV2, 14 = ProposalV2).
+///
+/// `DISCRIMINATOR` is therefore a memcmp predicate only. Slicing past
+/// `DISCRIMINATOR_OFFSET + DISCRIMINATOR.len()` and deserializing would drop the
+/// first field. Decode with `try_unpack`, as `parse_proposal_v2_account` does.
+///
+#[test]
+fn exposes_numeric_account_discriminators() {
+    assert_eq!(spl_governance::RealmV2::DISCRIMINATOR, [16_u8].as_slice());
+    assert_eq!(spl_governance::RealmV2::DISCRIMINATOR_OFFSET, 0);
+
+    assert_eq!(
+        spl_governance::ProposalV2::DISCRIMINATOR,
+        [14_u8].as_slice()
+    );
+    assert_eq!(spl_governance::ProposalV2::DISCRIMINATOR_OFFSET, 0);
+}

--- a/tests/proc-macro/tests/unicode_collision.rs
+++ b/tests/proc-macro/tests/unicode_collision.rs
@@ -1,0 +1,35 @@
+use shipstern_proc_macro::include_shipstern_parser;
+
+include_shipstern_parser!("../idls/unicode_collision.json");
+
+///
+/// `ä` and `Ä` are distinct instructions, with distinct `Instruction` variants
+/// and distinct `parse_*` helpers, so this IDL compiles. But
+/// `to_snake_case().to_uppercase()` folds both to `Ä`, because `to_snake_case`
+/// lowercases only ASCII while `to_uppercase` is Unicode-aware.
+///
+/// Neither instruction gets a constant: an ambiguous name is worse than none,
+/// and emitting both would make this feature the sole reason a previously valid
+/// IDL fails to compile. Referencing `Instructions::Ä_DISCRIMINATOR` here would
+/// fail to compile.
+///
+/// Parsing is unaffected, which is what this test pins.
+///
+#[test]
+fn colliding_const_names_are_skipped_without_breaking_parsing() {
+    let path = shipstern_core::instruction::Path::new_single(0);
+
+    let first =
+        unicode_collision::resolve_instruction_default(&[], &[0x11, 0x22, 0x33, 0x44], &path)
+            .expect("first instruction should still resolve");
+
+    let second =
+        unicode_collision::resolve_instruction_default(&[], &[0x55, 0x66, 0x77, 0x88], &path)
+            .expect("second instruction should still resolve");
+
+    assert_ne!(
+        std::mem::discriminant(&first.instruction),
+        std::mem::discriminant(&second.instruction),
+        "the two instructions must remain distinguishable"
+    );
+}


### PR DESCRIPTION
Closes #294.

Discriminator bytes only lived as literals inside the comparison checks and got thrown away after codegen, so nothing downstream could read them. This exposes them on the generated types.

```rust
impl BondingCurve {
    pub const DISCRIMINATOR: &'static [u8] = &[23, 183, 248, 55, 96, 216, 172, 96];
    pub const DISCRIMINATOR_OFFSET: usize = 0;
}

impl Instructions {
    pub const BUY_DISCRIMINATOR: &'static [u8] = &[102, 6, 61, 18, 1, 218, 235, 234];
    pub const BUY_DISCRIMINATOR_OFFSET: usize = 0;
}
```

The pair is a memcmp predicate: these bytes sit at that offset on the wire and they are what the parser matches, so they drop straight into `Memcmp::new_base58_encoded(offset, bytes)` or the geyser account filter.

They are **not** a payload boundary. SPL Governance deserializes from `data[..]`, so byte 0 is re-read as the first body field: `RealmV2::DISCRIMINATOR` is `&[16]`, which is also its `account_type` tag. Decode with `try_unpack`. No `DISCRIMINATOR_LEN` on purpose, since `OFFSET + LEN` math is the wrong move for that case.

Additive: `instruction_parser.rs` is +120/-0, the `account_parser.rs` `quote!` bodies are unchanged, and no match, filter or deserialize logic is touched.

### Skipped cases

No const where the parser could not honor it: size-only discriminators, zero-length ones, fixed-size fields whose declared width does not match the decoded bytes, and instruction names that collide after case folding. That last one matters because `ä` and `Ä` are distinct instructions that both fold to `Ä_DISCRIMINATOR`, so emitting would break an IDL that compiles today.

### Tests

Absence is compiler-checked (E0599). Covered: Anchor field discs (`dynamic_bonding_curve`), numeric consts with the re-read behavior asserted (`spl_governance`), a byte const at offset 8 behind a prefix so the `offset + len` path runs (`constant_bytes_account`), all 29 pump_fun instruction consts driven through `resolve_instruction_default`, and the `Buy` const checked against a real mainnet tx. New fixtures cover the four skip cases.

### Found while in here (not fixed)

- Width-mismatch matcher bug, same cause in two spots. This PR suppresses the const, matcher untouched. #296
- `SHOUTY`/`parse_*` name collision on ASCII case-only instruction names. #297
