### PR TITLE
ci: bust cargo cache keys after the org transfer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,10 +73,10 @@ jobs:
             target/debug/build/
             target/debug/.fingerprint/
             target/debug/deps/
-          key: cargo-build-${{ hashFiles('rust-toolchain.toml') }}-${{ hashFiles('**/Cargo.lock') }}
+          key: cargo-build-v2-${{ hashFiles('rust-toolchain.toml') }}-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            cargo-build-${{ hashFiles('rust-toolchain.toml') }}-
-            cargo-build-
+            cargo-build-v2-${{ hashFiles('rust-toolchain.toml') }}-
+            cargo-build-v2-
 
       # Project toolchain + clippy are auto-installed from rust-toolchain.toml
       - uses: dtolnay/rust-toolchain@stable
@@ -113,10 +113,10 @@ jobs:
             tests/proc-macro-events/target/debug/build/
             tests/proc-macro-events/target/debug/.fingerprint/
             tests/proc-macro-events/target/debug/deps/
-          key: cargo-events-${{ hashFiles('rust-toolchain.toml') }}-${{ hashFiles('tests/proc-macro-events/Cargo.lock') }}
+          key: cargo-events-v2-${{ hashFiles('rust-toolchain.toml') }}-${{ hashFiles('tests/proc-macro-events/Cargo.lock') }}
           restore-keys: |
-            cargo-events-${{ hashFiles('rust-toolchain.toml') }}-
-            cargo-events-
+            cargo-events-v2-${{ hashFiles('rust-toolchain.toml') }}-
+            cargo-events-v2-
 
       # Project toolchain + clippy are auto-installed from rust-toolchain.toml
       - uses: dtolnay/rust-toolchain@stable
@@ -146,10 +146,10 @@ jobs:
             target/debug/build/
             target/debug/.fingerprint/
             target/debug/deps/
-          key: cargo-build-${{ hashFiles('rust-toolchain.toml') }}-${{ hashFiles('**/Cargo.lock') }}
+          key: cargo-build-v2-${{ hashFiles('rust-toolchain.toml') }}-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            cargo-build-${{ hashFiles('rust-toolchain.toml') }}-
-            cargo-build-
+            cargo-build-v2-${{ hashFiles('rust-toolchain.toml') }}-
+            cargo-build-v2-
 
       # Project toolchain + clippy are auto-installed from rust-toolchain.toml
       - uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
`test`, `test-events` and `clippy` fail on every branch with a `Could not find protoc` panic from `crates/proto/build.rs`.

It's not a missing package. After the org transfer the checkout moved from `.../yellowstone-vixen` to `.../shipstern`, but the cache keys hash `rust-toolchain.toml` and `Cargo.lock`, and neither changed. So every job restores the old cache, cargo skips rebuilding `protobuf-src`, and its baked-in `OUT_DIR` still points at the old path. `build.rs` hands prost a `PROTOC` that no longer exists and panics. `fmt` passes because it never builds that crate.

A re-run can't fix it since `protobuf-src` never rebuilds. This bumps `cargo-build-` and `cargo-events-` to `-v2-` so the next run is cold, rebuilds under the new path, and saves a correct cache.

Adding `protobuf-compiler` to apt won't help: `build.rs` sets `PROTOC` explicitly, so prost never falls back to `PATH`.

Found while working on #295, which this is blocking.