### PR TITLE
feat(proc-macro): read the CPI event envelope from the IDL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ crates/mock/fixtures
 **/.DS_Store
 .cargo/
 Shipstern.toml
+
+# Local runtime config; may contain endpoint credentials.
+Vixen.toml

--- a/crates/proc-macro/src/lib.rs
+++ b/crates/proc-macro/src/lib.rs
@@ -34,7 +34,11 @@ pub fn include_shipstern_parser(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as IncludeShipsternParserInput);
 
     match input.parser_config() {
-        Ok(config) => expand_include_shipstern_parser(input.idl_path.value(), config),
+        Ok(config) => expand_include_shipstern_parser(
+            input.idl_path.value(),
+            config,
+            input.has_cpi_event_args(),
+        ),
         Err(err) => err.to_compile_error().into(),
     }
 }
@@ -123,6 +127,11 @@ impl Parse for IncludeShipsternParserInput {
 }
 
 impl IncludeShipsternParserInput {
+    /// Whether the call site supplied either CPI event override.
+    fn has_cpi_event_args(&self) -> bool {
+        self.cpi_event_discriminator.is_some() || self.cpi_event_payload_offset.is_some()
+    }
+
     fn parser_config(&self) -> syn::Result<crate::render::shipstern_parser::ParserConfig> {
         let mut config = crate::render::shipstern_parser::ParserConfig::default();
 
@@ -200,20 +209,217 @@ fn invalid_cpi_event_discriminator_hex(
 fn expand_include_shipstern_parser(
     idl_path: String,
     config: crate::render::shipstern_parser::ParserConfig,
+    has_cpi_event_args: bool,
 ) -> TokenStream {
     let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set");
 
     let full_path = std::path::Path::new(&manifest_dir).join(&idl_path);
 
-    match parse::load_codama_idl(&full_path) {
-        Ok((idl, events)) => crate::render::shipstern_parser(&idl, &events, &config).into(),
+    expand_parser_tokens(&full_path, config, has_cpi_event_args).into()
+}
+
+/// Split from `expand_include_shipstern_parser` so unit tests can reach the
+/// emission paths; a test cannot construct a `proc_macro::TokenStream`.
+fn expand_parser_tokens(
+    full_path: &std::path::Path,
+    mut config: crate::render::shipstern_parser::ParserConfig,
+    has_cpi_event_args: bool,
+) -> proc_macro2::TokenStream {
+    let (idl, events) = match parse::load_codama_idl(full_path) {
+        Ok(loaded) => loaded,
         Err(e) => {
             let error_msg = format!("Failed to load/parse IDL from {:?}: {}", full_path, e);
 
-            quote::quote! {
+            return quote::quote! {
                 compile_error!(#error_msg);
-            }
-            .into()
+            };
         },
+    };
+
+    // The IDL wins; macro args remain a fallback for IDLs declaring no envelope.
+    let envelope = match parse::program_envelope(&events) {
+        Ok(envelope) => envelope,
+        Err(message) => {
+            let error_msg = format!("Invalid CPI event envelope in {:?}: {}", full_path, message);
+
+            return quote::quote! {
+                compile_error!(#error_msg);
+            };
+        },
+    };
+
+    let deprecation = match &envelope {
+        Some(envelope) => {
+            config.cpi_event.discriminator = envelope.envelope.discriminator.clone();
+            config.cpi_event.payload_offset = envelope.envelope.payload_offset;
+            config.idl_envelope = Some(envelope.clone());
+
+            if has_cpi_event_args {
+                cpi_event_args_deprecation()
+            } else {
+                quote::quote! {}
+            }
+        },
+
+        None => quote::quote! {},
+    };
+
+    // Checked against the resolved tag, so the macro-arg fallback and the Anchor
+    // default are covered too, not just IDL-declared envelopes.
+    if let Some(message) = parse::envelope_instruction_collision(
+        &config.cpi_event.discriminator,
+        &idl.program.instructions,
+    ) {
+        let error_msg = format!("Invalid CPI event envelope in {:?}: {}", full_path, message);
+
+        return quote::quote! {
+            compile_error!(#error_msg);
+        };
+    }
+
+    let parser = crate::render::shipstern_parser(&idl, &events, &config);
+
+    quote::quote! {
+        #deprecation
+        #parser
+    }
+}
+
+/// Proc macros cannot emit diagnostics on stable, so the warning rides the
+/// deprecation lint instead.
+fn cpi_event_args_deprecation() -> proc_macro2::TokenStream {
+    quote::quote! {
+        const _: () = {
+            #[deprecated(
+                note = "the IDL declares a CPI event envelope, so cpi_event_discriminator and \
+                        cpi_event_payload_offset are ignored; these arguments are removed in 0.10"
+            )]
+            const CPI_EVENT_ARGS_IGNORED: () = ();
+
+            let _ = CPI_EVENT_ARGS_IGNORED;
+        };
+    }
+}
+
+#[cfg(test)]
+mod expansion_tests {
+    use super::*;
+
+    fn fixture(name: &str) -> std::path::PathBuf {
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../tests/idls")
+            .join(name)
+    }
+
+    fn expand(name: &str, has_cpi_event_args: bool) -> String {
+        expand_parser_tokens(
+            &fixture(name),
+            crate::render::shipstern_parser::ParserConfig::default(),
+            has_cpi_event_args,
+        )
+        .to_string()
+    }
+
+    /// Guards the wiring: the collision verdict is unit-tested on its own, but
+    /// nothing else proves it is emitted rather than computed and dropped.
+    #[test]
+    fn colliding_envelope_is_emitted_as_a_compile_error() {
+        let tokens = expand("colliding_envelope.json", false);
+
+        assert!(tokens.contains("compile_error"), "no compile_error emitted");
+        assert!(
+            tokens.contains("collides with instruction"),
+            "collision message did not reach the emitted tokens: {tokens}",
+        );
+    }
+
+    /// The same IDL with a non-colliding tag must expand to a real parser.
+    #[test]
+    fn non_colliding_envelope_expands_normally() {
+        let tokens = expand("collision_safe_cpi_event_envelope.json", false);
+
+        assert!(
+            !tokens.contains("compile_error"),
+            "unexpected compile_error: {tokens}",
+        );
+        assert!(tokens.contains("InstructionParser"));
+    }
+
+    /// Mismatched payload offsets must also reach `compile_error!`.
+    #[test]
+    fn envelope_validation_errors_are_emitted() {
+        let tokens = expand("mismatched_payload_offsets.json", false);
+
+        assert!(tokens.contains("compile_error"), "no compile_error emitted");
+        assert!(
+            tokens.contains("different offsets"),
+            "validation message did not reach the emitted tokens: {tokens}",
+        );
+    }
+
+    /// The guard runs on the resolved tag, so the macro-arg fallback is covered
+    /// even though no envelope is declared in the IDL.
+    #[test]
+    fn macro_arg_envelope_colliding_with_an_instruction_is_rejected() {
+        let mut config = crate::render::shipstern_parser::ParserConfig::default();
+        config.cpi_event.discriminator = vec![0x09];
+        config.cpi_event.payload_offset = 1;
+
+        let tokens =
+            expand_parser_tokens(&fixture("macro_arg_envelope_collision.json"), config, true)
+                .to_string();
+
+        assert!(tokens.contains("compile_error"), "no compile_error emitted");
+        assert!(
+            tokens.contains("collides with instruction"),
+            "collision message missing: {tokens}",
+        );
+    }
+
+    /// The same IDL on the Anchor default builds clean.
+    #[test]
+    fn macro_arg_fixture_builds_on_the_anchor_default() {
+        let tokens = expand("macro_arg_envelope_collision.json", false);
+
+        assert!(
+            !tokens.contains("compile_error"),
+            "unexpected compile_error: {tokens}",
+        );
+    }
+
+    /// An undecodable envelope discriminator reports, rather than panicking the
+    /// macro through the shared decoder's `expect`.
+    #[test]
+    fn malformed_envelope_discriminator_is_reported() {
+        let tokens = expand("malformed_envelope_discriminator.json", false);
+
+        assert!(tokens.contains("compile_error"), "no compile_error emitted");
+        assert!(
+            tokens.contains("not valid"),
+            "decode message missing: {tokens}",
+        );
+    }
+
+    /// The deprecation fires only when an IDL envelope and macro args conflict.
+    #[test]
+    fn deprecation_fires_only_on_conflict() {
+        let conflicting = expand("padded_cpi_event_envelope.json", true);
+        assert!(
+            conflicting.contains("CPI_EVENT_ARGS_IGNORED"),
+            "IDL envelope plus macro args must warn",
+        );
+
+        let idl_only = expand("padded_cpi_event_envelope.json", false);
+        assert!(
+            !idl_only.contains("CPI_EVENT_ARGS_IGNORED"),
+            "an IDL envelope alone must not warn",
+        );
+
+        // The supported 0.8.0 fallback: macro args with no IDL envelope.
+        let args_only = expand("single_discriminator_event.json", true);
+        assert!(
+            !args_only.contains("CPI_EVENT_ARGS_IGNORED"),
+            "macro args without an IDL envelope must not warn",
+        );
     }
 }

--- a/crates/proc-macro/src/parse.rs
+++ b/crates/proc-macro/src/parse.rs
@@ -51,3 +51,575 @@ fn fix_string_error_codes(value: &mut serde_json::Value) {
         }
     }
 }
+
+///
+/// The self-CPI event envelope declared by an IDL.
+///
+/// `emit_cpi!` data is `[envelope tag][event discriminator][borsh payload]`.
+/// Codama has no node for the tag, so it is inferred positionally from the
+/// discriminator chain, the same rule Carbon's renderer uses.
+///
+/// Example input:
+///
+/// ```rust, ignore
+/// // discriminators: [const e445a52e51cb9a1d @0, const 40c6cde8260871e2 @8]
+/// //   -> discriminator = e445a52e51cb9a1d, payload_offset = 8
+/// ```
+///
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CpiEventEnvelope {
+    /// Envelope tag bytes, always at offset 0 of the inner instruction data.
+    pub discriminator: Vec<u8>,
+
+    /// Byte offset at which the event's own discriminator begins.
+    ///
+    /// The declared offset of the next discriminator, not the tag length, so
+    /// padded layouts round-trip.
+    pub payload_offset: usize,
+}
+
+/// Decode without the shared helper's `expect`, so a malformed envelope
+/// discriminator reaches `compile_error!` instead of panicking the macro.
+fn try_decode_bytes(bytes: &codama_nodes::BytesValueNode) -> Option<Vec<u8>> {
+    match bytes.encoding {
+        codama_nodes::BytesEncoding::Base16 => hex::decode(crate::utils::pad_hex(&bytes.data)).ok(),
+        codama_nodes::BytesEncoding::Base58 => bs58::decode(&bytes.data).into_vec().ok(),
+        codama_nodes::BytesEncoding::Base64 => {
+            use base64::Engine as _;
+            base64::engine::general_purpose::STANDARD
+                .decode(&bytes.data)
+                .ok()
+        },
+        codama_nodes::BytesEncoding::Utf8 => Some(bytes.data.as_bytes().to_vec()),
+    }
+}
+
+/// Numeric constants narrow to one byte, matching the generated match arm's
+/// `*d == (value as u8)`.
+fn constant_discriminator_bytes(
+    node: &codama_nodes::ConstantDiscriminatorNode,
+) -> Result<Vec<u8>, String> {
+    match node.constant.value.as_ref() {
+        codama_nodes::ValueNode::Bytes(bytes) => try_decode_bytes(bytes).ok_or_else(|| {
+            format!(
+                "discriminator at offset {} is not valid {:?} data",
+                node.offset, bytes.encoding,
+            )
+        }),
+
+        codama_nodes::ValueNode::Number(number) => {
+            let codama_nodes::Number::UnsignedInteger(value) = number.number else {
+                return Err(format!(
+                    "discriminator at offset {} is a signed or floating-point number",
+                    node.offset,
+                ));
+            };
+
+            Ok(vec![value as u8])
+        },
+
+        _ => Err(format!(
+            "discriminator at offset {} is neither bytes nor an unsigned number",
+            node.offset,
+        )),
+    }
+}
+
+///
+/// Infer the CPI event envelope declared by a single event, if any.
+///
+/// `Ok(None)` means no envelope: a single discriminator, or any non-constant
+/// one in the chain. Those events keep their existing meaning and stay
+/// matchable from `Program data:` log lines, which carry no envelope.
+///
+/// `Err` is reserved for chains that look enveloped but cannot be honored, so
+/// an ambiguous IDL fails the build rather than parsing arbitrarily.
+///
+pub fn envelope_of(event: &codama_nodes::EventNode) -> Result<Option<CpiEventEnvelope>, String> {
+    let mut constants = Vec::with_capacity(event.discriminators.len());
+
+    for discriminator in &event.discriminators {
+        let codama_nodes::DiscriminatorNode::Constant(node) = discriminator else {
+            continue;
+        };
+
+        constants.push(node);
+    }
+
+    let leads_with_constant = constants.iter().any(|node| node.offset == 0);
+
+    // A chain that opens with a tag but mixes in a non-constant node cannot be
+    // rebased, and treating it as unenveloped would match the tag against
+    // already-stripped data, so the event would silently never fire.
+    if constants.len() != event.discriminators.len() {
+        if event.discriminators.len() >= 2 && leads_with_constant {
+            return Err(format!(
+                "event `{}` mixes constant and non-constant discriminators behind a constant at \
+                 offset 0; a CPI event envelope needs an all-constant chain",
+                *event.name,
+            ));
+        }
+
+        return Ok(None);
+    }
+
+    if constants.len() < 2 {
+        return Ok(None);
+    }
+
+    {
+        let at_zero = constants.iter().filter(|node| node.offset == 0).count();
+
+        if at_zero == 0 {
+            return Ok(None);
+        }
+
+        // Nothing distinguishes envelope from event discriminator here, and
+        // declaration order would decide it silently.
+        if at_zero > 1 {
+            return Err(format!(
+                "event `{}` declares {at_zero} discriminators at offset 0; a CPI event envelope \
+                 needs exactly one",
+                *event.name,
+            ));
+        }
+    }
+
+    let mut sorted = constants;
+    sorted.sort_by_key(|node| node.offset);
+
+    let mut decoded = Vec::with_capacity(sorted.len());
+
+    for node in &sorted {
+        let bytes = constant_discriminator_bytes(node)
+            .map_err(|reason| format!("event `{}` has a {reason}", *event.name))?;
+
+        decoded.push((node.offset, bytes));
+    }
+
+    // Overlap makes at least one arm unmatchable. Gaps are allowed: padded
+    // envelopes are a real layout.
+    for window in decoded.windows(2) {
+        let (offset, bytes) = &window[0];
+        let (next_offset, _) = &window[1];
+
+        if offset + bytes.len() > *next_offset {
+            return Err(format!(
+                "event `{}` has overlapping discriminators: {} bytes at offset {offset} run past \
+                 offset {next_offset}",
+                *event.name,
+                bytes.len(),
+            ));
+        }
+    }
+
+    let (_, discriminator) = decoded[0].clone();
+    let (payload_offset, _) = decoded[1];
+
+    Ok(Some(CpiEventEnvelope {
+        discriminator,
+        payload_offset,
+    }))
+}
+
+///
+/// Infer the program-wide CPI event envelope from its events.
+///
+/// The envelope belongs to the program, so every event declaring one must
+/// agree. Events declaring none are exempt: a program may mix `emit_cpi!` and
+/// `emit!` events, and rejecting that would fail programs that parse fine.
+/// Carbon instead bails on the whole program in that case.
+///
+pub fn program_envelope(
+    events: &[codama_nodes::EventNode],
+) -> Result<Option<ProgramEnvelope>, String> {
+    let mut found: Option<(String, CpiEventEnvelope)> = None;
+    let mut enveloped = Vec::with_capacity(events.len());
+    let mut lone_constants: Vec<(String, Vec<u8>)> = Vec::new();
+
+    for event in events {
+        let Some(envelope) = envelope_of(event)? else {
+            enveloped.push((event.name.to_string(), false));
+
+            if let [codama_nodes::DiscriminatorNode::Constant(node)] = &event.discriminators[..]
+                && node.offset == 0
+                && let Ok(bytes) = constant_discriminator_bytes(node)
+            {
+                lone_constants.push((event.name.to_string(), bytes));
+            }
+
+            continue;
+        };
+
+        enveloped.push((event.name.to_string(), true));
+
+        let Some((first_name, first)) = &found else {
+            found = Some((event.name.to_string(), envelope));
+            continue;
+        };
+
+        if first.discriminator != envelope.discriminator {
+            return Err(format!(
+                "events `{}` and `{}` declare different CPI event envelopes ({} vs {}); one \
+                 program has one envelope",
+                first_name,
+                *event.name,
+                hex::encode(&first.discriminator),
+                hex::encode(&envelope.discriminator),
+            ));
+        }
+
+        // The parser strips one `payload_offset` for every event, so events
+        // padding differently behind the same tag would decode off by the
+        // difference.
+        if first.payload_offset != envelope.payload_offset {
+            return Err(format!(
+                "events `{}` and `{}` share a CPI event envelope but start their payloads at \
+                 different offsets ({} vs {}); one program has one payload offset",
+                first_name, *event.name, first.payload_offset, envelope.payload_offset,
+            ));
+        }
+    }
+
+    let Some((_, envelope)) = found else {
+        return Ok(None);
+    };
+
+    // A lone discriminator equal to the tag is the envelope with no event
+    // discriminator behind it. It would be matched against already-stripped
+    // data and never fire.
+    for (name, bytes) in lone_constants {
+        if bytes == envelope.discriminator {
+            return Err(format!(
+                "event `{name}` declares only the CPI event envelope {} as its discriminator, so \
+                 it has none of its own",
+                hex::encode(&envelope.discriminator),
+            ));
+        }
+    }
+
+    Ok(Some(ProgramEnvelope {
+        envelope,
+        enveloped,
+    }))
+}
+
+///
+/// A program's CPI event envelope plus which events declare it.
+///
+/// Both come from the same validated pass, so codegen never re-decides whether
+/// an event is enveloped; it looks the answer up by index.
+///
+#[derive(Debug, Clone)]
+pub struct ProgramEnvelope {
+    /// The envelope every declaring event agrees on.
+    pub envelope: CpiEventEnvelope,
+
+    /// Per-event verdict, keyed by name and positionally aligned with the
+    /// events slice.
+    enveloped: Vec<(String, bool)>,
+}
+
+impl ProgramEnvelope {
+    ///
+    /// Resolve every event's envelope against the slice the verdicts were built
+    /// from.
+    ///
+    /// Panics, surfacing as a build error, when the slice does not match the one
+    /// validated: the verdicts are positional, so a caller that filtered or
+    /// reordered events would hand each event its neighbour's answer.
+    ///
+    pub fn resolve<'a>(&'a self, events: &[EventNode]) -> Vec<Option<&'a CpiEventEnvelope>> {
+        assert_eq!(
+            events.len(),
+            self.enveloped.len(),
+            "CPI event envelope verdicts were built for {} events but resolved against {}; the \
+             events slice changed between validation and codegen",
+            self.enveloped.len(),
+            events.len(),
+        );
+
+        self.enveloped
+            .iter()
+            .zip(events)
+            .map(|((name, enveloped), event)| {
+                assert_eq!(
+                    name.as_str(),
+                    &**event.name,
+                    "CPI event envelope verdicts are out of order; expected `{name}`",
+                );
+
+                enveloped.then_some(&self.envelope)
+            })
+            .collect()
+    }
+}
+
+///
+/// The instruction an envelope tag would mask, if any.
+///
+/// The parser filters instructions whose data starts with the tag before it
+/// dispatches, so one sharing a prefix with the tag at offset 0 can never be
+/// parsed. Anchor's dispatcher checks the sentinel after every instruction, so
+/// this drops real instructions rather than being a theoretical clash.
+///
+/// A collision is either sequence prefixing the other at offset 0, equality
+/// included. Only offset 0 counts, because that is what `starts_with` compares.
+///
+pub fn envelope_instruction_collision(
+    discriminator: &[u8],
+    instructions: &[codama_nodes::InstructionNode],
+) -> Option<String> {
+    for instruction in instructions {
+        let Some(key) =
+            crate::render::instruction_parser::extract_ix_discriminator_key(instruction)
+        else {
+            continue;
+        };
+
+        let Some((bytes, offset)) = key.to_bytes_offset() else {
+            continue;
+        };
+
+        if offset != 0 || bytes.is_empty() {
+            continue;
+        }
+
+        let shared = bytes.len().min(discriminator.len());
+
+        if bytes[..shared] != discriminator[..shared] {
+            continue;
+        }
+
+        return Some(format!(
+            "CPI event envelope {} collides with instruction `{}` (discriminator {} at offset 0); \
+             the generated parser filters every instruction whose data starts with the envelope \
+             tag, so `{}` would never parse",
+            hex::encode(discriminator),
+            *instruction.name,
+            hex::encode(&bytes),
+            *instruction.name,
+        ));
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn event(name: &str, discriminators: &str) -> EventNode {
+        let json = format!(
+            r#"{{"kind":"eventNode","name":"{name}","data":{{"kind":"structTypeNode","fields":[]}},
+                "discriminators":[{discriminators}]}}"#
+        );
+
+        serde_json::from_str(&json).expect("event fixture")
+    }
+
+    fn constant(hex: &str, offset: usize) -> String {
+        let size = hex.len() / 2;
+
+        format!(
+            r#"{{"kind":"constantDiscriminatorNode","offset":{offset},"constant":{{
+                "kind":"constantValueNode",
+                "type":{{"kind":"fixedSizeTypeNode","size":{size},"type":{{"kind":"bytesTypeNode"}}}},
+                "value":{{"kind":"bytesValueNode","data":"{hex}","encoding":"base16"}}}}}}"#
+        )
+    }
+
+    fn instruction(name: &str, hex: &str, offset: usize) -> codama_nodes::InstructionNode {
+        let size = hex.len() / 2;
+
+        let json = format!(
+            r#"{{"kind":"instructionNode","name":"{name}","accounts":[],
+                "arguments":[{{"kind":"instructionArgumentNode","name":"discriminator",
+                    "defaultValueStrategy":"omitted",
+                    "type":{{"kind":"fixedSizeTypeNode","size":{size},"type":{{"kind":"bytesTypeNode"}}}},
+                    "defaultValue":{{"kind":"bytesValueNode","data":"{hex}","encoding":"base16"}}}}],
+                "discriminators":[{{"kind":"fieldDiscriminatorNode","name":"discriminator","offset":{offset}}}]}}"#
+        );
+
+        serde_json::from_str(&json).expect("instruction fixture")
+    }
+
+    /// Events padding differently behind one tag would each need their own
+    /// strip, but the generated parser has a single `EVENT_PAYLOAD_OFFSET`.
+    #[test]
+    fn program_envelope_rejects_mismatched_payload_offsets() {
+        let events = vec![
+            event(
+                "alpha",
+                &format!("{},{}", constant("fe", 0), constant("a1a2", 4)),
+            ),
+            event(
+                "beta",
+                &format!("{},{}", constant("fe", 0), constant("b1b2", 6)),
+            ),
+        ];
+
+        let err = program_envelope(&events).expect_err("mismatched payload offsets must fail");
+
+        assert!(
+            err.contains(
+                "share a CPI event envelope but start their payloads at different offsets (4 vs 6)"
+            ),
+            "unexpected message: {err}",
+        );
+    }
+
+    #[test]
+    fn program_envelope_accepts_matching_payload_offsets() {
+        let events = vec![
+            event(
+                "alpha",
+                &format!("{},{}", constant("fe", 0), constant("a1a2", 4)),
+            ),
+            event(
+                "beta",
+                &format!("{},{}", constant("fe", 0), constant("b1b2", 4)),
+            ),
+        ];
+
+        let envelope = program_envelope(&events)
+            .expect("matching offsets are valid")
+            .expect("an envelope was declared");
+
+        assert_eq!(envelope.envelope.discriminator, vec![0xfe]);
+        assert_eq!(envelope.envelope.payload_offset, 4);
+    }
+
+    /// A program mixing `emit_cpi!` and `emit!` events must not fail.
+    #[test]
+    fn program_envelope_allows_events_without_an_envelope() {
+        let events = vec![
+            event(
+                "enveloped",
+                &format!("{},{}", constant("fe", 0), constant("a1a2", 4)),
+            ),
+            event("logOnly", &constant("b1b2", 0)),
+        ];
+
+        let envelope = program_envelope(&events)
+            .expect("a mixed program is valid")
+            .expect("the enveloped event still declares one");
+
+        let resolved = envelope.resolve(&events);
+
+        assert!(resolved[0].is_some(), "enveloped event keeps its envelope");
+        assert!(resolved[1].is_none(), "log-only event has none");
+    }
+
+    /// A chain behind a tag must be all constants; a mixed one cannot be rebased.
+    #[test]
+    fn envelope_of_rejects_a_mixed_chain_behind_a_tag() {
+        let json = format!(
+            r#"{{"kind":"eventNode","name":"mixed","data":{{"kind":"structTypeNode","fields":[]}},
+                "discriminators":[{},{{"kind":"fieldDiscriminatorNode","name":"d","offset":8}}]}}"#,
+            constant("fe", 0),
+        );
+
+        let event: EventNode = serde_json::from_str(&json).expect("event fixture");
+        let err = envelope_of(&event).expect_err("a mixed chain must fail");
+
+        assert!(err.contains("mixes constant and non-constant"), "{err}");
+    }
+
+    /// A single non-constant discriminator is still just an unenveloped event.
+    #[test]
+    fn envelope_of_allows_a_lone_non_constant_discriminator() {
+        let json = r#"{"kind":"eventNode","name":"fieldOnly","data":{"kind":"structTypeNode","fields":[]},
+             "discriminators":[{"kind":"fieldDiscriminatorNode","name":"d","offset":0}]}"#;
+
+        let event: EventNode = serde_json::from_str(json).expect("event fixture");
+
+        assert_eq!(envelope_of(&event).expect("not an error"), None);
+    }
+
+    /// An event whose only discriminator is the program tag has none of its own.
+    #[test]
+    fn program_envelope_rejects_an_event_that_is_only_the_tag() {
+        let events = vec![
+            event(
+                "enveloped",
+                &format!("{},{}", constant("fe", 0), constant("a1a2", 4)),
+            ),
+            event("tagOnly", &constant("fe", 0)),
+        ];
+
+        let err = program_envelope(&events).expect_err("tag-only event must fail");
+
+        assert!(
+            err.contains("declares only the CPI event envelope"),
+            "{err}"
+        );
+    }
+
+    /// A normal single-discriminator event, the shape of every existing IDL,
+    /// must stay accepted alongside an enveloped one.
+    #[test]
+    fn program_envelope_keeps_ordinary_single_discriminator_events() {
+        let events = vec![
+            event(
+                "enveloped",
+                &format!("{},{}", constant("fe", 0), constant("a1a2", 4)),
+            ),
+            event("logOnly", &constant("b1b2", 0)),
+        ];
+
+        let envelope = program_envelope(&events)
+            .expect("an ordinary event must not be rejected")
+            .expect("the enveloped event declares one");
+
+        let resolved = envelope.resolve(&events);
+
+        assert!(resolved[0].is_some());
+        assert!(resolved[1].is_none());
+    }
+
+    /// A one-byte envelope masks a one-byte instruction discriminator entirely.
+    #[test]
+    fn collision_detected_when_envelope_masks_an_instruction() {
+        let instructions = vec![instruction("swapBaseIn", "09", 0)];
+
+        let message = envelope_instruction_collision(&[0x09], &instructions)
+            .expect("a masked instruction must be reported");
+
+        assert!(
+            message.contains("envelope 09 collides with instruction `swapBaseIn`"),
+            "{message}"
+        );
+        assert!(message.contains("would never parse"), "{message}");
+    }
+
+    /// The envelope is compared only against instructions, never instruction to
+    /// instruction, so variants that deliberately share a discriminator are not
+    /// the guard's business.
+    #[test]
+    fn no_collision_when_instructions_share_a_discriminator_but_envelope_differs() {
+        let instructions = vec![
+            instruction("swapBaseIn", "09", 0),
+            instruction("swapBaseInCompact", "09", 0),
+        ];
+
+        assert!(envelope_instruction_collision(&[0xfe], &instructions).is_none());
+    }
+
+    /// A shorter instruction discriminator that prefixes the tag is a partial
+    /// mask: data continuing with the tag's remaining bytes is swallowed.
+    #[test]
+    fn collision_detected_when_instruction_prefixes_the_envelope() {
+        let instructions = vec![instruction("swapBaseIn", "09", 0)];
+
+        assert!(envelope_instruction_collision(&[0x09, 0xaa], &instructions).is_some());
+    }
+
+    #[test]
+    fn no_collision_for_the_anchor_tag_against_ordinary_instructions() {
+        let anchor = [0xe4, 0x45, 0xa5, 0x2e, 0x51, 0xcb, 0x9a, 0x1d];
+        let instructions = vec![instruction("route", "0102030405060708", 0)];
+
+        assert!(envelope_instruction_collision(&anchor, &instructions).is_none());
+    }
+}

--- a/crates/proc-macro/src/render/event_parser.rs
+++ b/crates/proc-macro/src/render/event_parser.rs
@@ -9,32 +9,47 @@ use quote::{format_ident, quote};
 /// The event resolution functions are called by `InstructionParser` (when
 /// `program-events` feature is active) to handle CPI and log-based events.
 ///
+/// An event paired with the envelope resolved for it by the validated pass.
+type EnvelopedEvent<'a> = (
+    &'a codama_nodes::EventNode,
+    Option<&'a crate::parse::CpiEventEnvelope>,
+);
+
 pub fn event_parser(
     _program_name_camel: &CamelCaseString,
     events: &[codama_nodes::EventNode],
     has_instructions: bool,
+    envelope: Option<&crate::parse::ProgramEnvelope>,
 ) -> TokenStream {
     let wrapper_ident = format_ident!("Events");
     let ev_mod = format_ident!("event");
 
     // Per-event parse helper functions
+    // Resolved once from the validated pass so no codegen site re-decides it.
+    let event_envelopes: Vec<Option<&crate::parse::CpiEventEnvelope>> = envelope.map_or_else(
+        || vec![None; events.len()],
+        |program| program.resolve(events),
+    );
+
     let helper_fns: Vec<TokenStream> = events
         .iter()
-        .filter_map(|ev| single_event_helper_fn(ev, &wrapper_ident, &ev_mod))
+        .zip(&event_envelopes)
+        .filter_map(|(ev, envelope)| single_event_helper_fn(ev, &wrapper_ident, &ev_mod, *envelope))
         .collect();
 
     // Discriminator match arms
     let mut groups: Vec<(
         super::instruction_parser::DiscriminatorKey,
-        Vec<&codama_nodes::EventNode>,
+        Vec<EnvelopedEvent<'_>>,
     )> = Vec::new();
 
-    for ev in events {
-        if let Some(key) = super::instruction_parser::extract_event_discriminator_key(ev) {
+    for (ev, envelope) in events.iter().zip(&event_envelopes) {
+        if let Some(key) = super::instruction_parser::extract_event_discriminator_key(ev, *envelope)
+        {
             if let Some(group) = groups.iter_mut().find(|(k, _)| k == &key) {
-                group.1.push(ev);
+                group.1.push((ev, *envelope));
             } else {
-                groups.push((key, vec![ev]));
+                groups.push((key, vec![(ev, *envelope)]));
             }
         }
     }
@@ -43,11 +58,11 @@ pub fn event_parser(
         .iter()
         .filter_map(|(_, evs)| {
             if evs.len() == 1 {
-                single_event_match_arm(evs[0], &ev_mod)
+                single_event_match_arm(evs[0].0, &ev_mod, evs[0].1)
             } else {
                 // Events shouldn't have discriminator collisions in practice.
                 // If they do, emit a compile-time error directing the user to investigate.
-                let names: Vec<_> = evs.iter().map(|e| e.name.to_string()).collect();
+                let names: Vec<_> = evs.iter().map(|(e, _)| e.name.to_string()).collect();
                 let msg = format!(
                     "Event discriminator collision: [{}] share the same discriminator.",
                     names.join(", ")
@@ -271,6 +286,7 @@ fn single_event_helper_fn(
     event: &codama_nodes::EventNode,
     wrapper_ident: &syn::Ident,
     ev_mod: &syn::Ident,
+    envelope: Option<&crate::parse::CpiEventEnvelope>,
 ) -> Option<TokenStream> {
     let ev_name_pascal = crate::utils::to_pascal_case(&event.name);
     let ev_name_snake = crate::utils::to_snake_case(&event.name);
@@ -289,6 +305,7 @@ fn single_event_helper_fn(
         &args_ident,
         has_args,
         ev_mod,
+        envelope,
     )?;
 
     // Events have no accounts — only remaining_accounts (always empty vec)
@@ -322,6 +339,7 @@ fn single_event_helper_fn(
 fn single_event_match_arm(
     event: &codama_nodes::EventNode,
     ev_mod: &syn::Ident,
+    envelope: Option<&crate::parse::CpiEventEnvelope>,
 ) -> Option<TokenStream> {
     let ev_name_snake = crate::utils::to_snake_case(&event.name);
     let fn_ident = format_ident!("parse_event_{}", ev_name_snake);
@@ -336,6 +354,7 @@ fn single_event_match_arm(
         &args_ident,
         has_args,
         ev_mod,
+        envelope,
     )?;
 
     let check = info.check;

--- a/crates/proc-macro/src/render/instruction_parser.rs
+++ b/crates/proc-macro/src/render/instruction_parser.rs
@@ -32,7 +32,7 @@ impl DiscriminatorKey {
 }
 
 /// Decode discriminator bytes from a codama [`BytesValueNode`](codama_nodes::BytesValueNode).
-fn decode_discriminator_field_bytes(bytes: &codama_nodes::BytesValueNode) -> Vec<u8> {
+pub(crate) fn decode_discriminator_field_bytes(bytes: &codama_nodes::BytesValueNode) -> Vec<u8> {
     match bytes.encoding {
         codama_nodes::BytesEncoding::Base16 => {
             let padded = crate::utils::pad_hex(&bytes.data);
@@ -123,11 +123,68 @@ fn ix_discriminator_slice_width(ix: &codama_nodes::InstructionNode) -> Option<us
     }
 }
 
+///
+/// An event's own discriminators, rebased onto the envelope-stripped layout.
+///
+/// Both paths hand `resolve_event_default` data with no envelope: the CPI
+/// caller slices it off at `payload_offset`, and log lines never had one. IDL
+/// offsets describe the enveloped layout, so subtracting `payload_offset` puts
+/// both paths on the same layout and one set of offsets serves both.
+///
+/// Example output:
+///
+/// ```rust, ignore
+/// // IDL:      [const e445..@0, const 40c6..@8]
+/// // rebased:  [const 40c6..@0]
+/// ```
+///
+/// `None` when this event declares no envelope, as resolved by the caller from
+/// the validated pass; its discriminators already describe the stripped layout.
+///
+fn rebased_event_discriminators(
+    ev: &codama_nodes::EventNode,
+    envelope: Option<&crate::parse::CpiEventEnvelope>,
+) -> Option<Vec<DiscriminatorNode>> {
+    let envelope = envelope?;
+
+    let mut rebased: Vec<_> = ev
+        .discriminators
+        .iter()
+        .filter_map(|discriminator| {
+            let DiscriminatorNode::Constant(node) = discriminator else {
+                return None;
+            };
+
+            // The envelope itself is the constant at offset 0.
+            if node.offset == 0 {
+                return None;
+            }
+
+            let mut node = node.clone();
+            node.offset -= envelope.payload_offset;
+
+            Some(DiscriminatorNode::Constant(node))
+        })
+        .collect();
+
+    rebased.sort_by_key(|discriminator| match discriminator {
+        DiscriminatorNode::Constant(node) => node.offset,
+        _ => 0,
+    });
+
+    Some(rebased)
+}
+
 /// Extract a discriminator key for an event (collision detection).
 pub(crate) fn extract_event_discriminator_key(
     ev: &codama_nodes::EventNode,
+    envelope: Option<&crate::parse::CpiEventEnvelope>,
 ) -> Option<DiscriminatorKey> {
-    extract_discriminator_key(&ev.discriminators, |name| resolve_event_field(ev, name))
+    let rebased = rebased_event_discriminators(ev, envelope);
+
+    let discriminators = rebased.as_deref().unwrap_or(&ev.discriminators);
+
+    extract_discriminator_key(discriminators, |name| resolve_event_field(ev, name))
 }
 
 /// Extract discriminator info for an instruction (match arm + args deserialization).
@@ -146,20 +203,63 @@ pub(crate) fn extract_ix_discriminator_info(
     )
 }
 
+///
 /// Extract discriminator info for an event (match arm + args deserialization).
+///
+/// A rebased chain of two or more discriminators is combined with `&&` and the
+/// payload read after the last one. A single discriminator delegates to the
+/// same code the pre-chain path ran, so IDLs declaring no envelope are
+/// behaviourally unchanged; generated tokens are not diffed.
+///
 pub(crate) fn extract_event_discriminator_info(
     ev: &codama_nodes::EventNode,
     args_ident: &syn::Ident,
     has_args: bool,
     mod_ident: &syn::Ident,
+    envelope: Option<&crate::parse::CpiEventEnvelope>,
 ) -> Option<DiscriminatorInfo> {
-    extract_discriminator_info(
-        &ev.discriminators,
+    let Some(rebased) = rebased_event_discriminators(ev, envelope) else {
+        return extract_discriminator_info(
+            &ev.discriminators,
+            args_ident,
+            has_args,
+            mod_ident,
+            |name| resolve_event_field(ev, name),
+        );
+    };
+
+    let (last, leading) = rebased.split_last()?;
+
+    // Args start after the last discriminator, so only that one contributes the
+    // payload expression; the rest contribute checks alone.
+    let tail = extract_discriminator_info(
+        std::slice::from_ref(last),
         args_ident,
         has_args,
         mod_ident,
         |name| resolve_event_field(ev, name),
-    )
+    )?;
+
+    let mut checks = Vec::with_capacity(rebased.len());
+
+    for discriminator in leading {
+        let info = extract_discriminator_info(
+            std::slice::from_ref(discriminator),
+            args_ident,
+            false,
+            mod_ident,
+            |name| resolve_event_field(ev, name),
+        )?;
+
+        checks.push(info.check);
+    }
+
+    checks.push(tail.check);
+
+    Some(DiscriminatorInfo {
+        args_expr: tail.args_expr,
+        check: quote! { #((#checks))&&* },
+    })
 }
 
 fn extract_discriminator_key(

--- a/crates/proc-macro/src/render/shipstern_parser.rs
+++ b/crates/proc-macro/src/render/shipstern_parser.rs
@@ -5,6 +5,16 @@ use quote::{format_ident, quote};
 #[derive(Debug, Clone)]
 pub struct ParserConfig {
     pub cpi_event: CpiEventConfig,
+
+    ///
+    /// The envelope the IDL declared, validated once by
+    /// [`crate::parse::program_envelope`].
+    ///
+    /// `None` when the IDL declares none, in which case `cpi_event` came from
+    /// the macro arguments or the Anchor default and no event discriminator is
+    /// rebased.
+    ///
+    pub idl_envelope: Option<crate::parse::ProgramEnvelope>,
 }
 
 #[derive(Debug, Clone)]
@@ -22,6 +32,7 @@ impl Default for ParserConfig {
                 discriminator: anchor_event_tag.to_vec(),
                 payload_offset: anchor_event_tag.len(),
             },
+            idl_envelope: None,
         }
     }
 }
@@ -71,7 +82,12 @@ pub fn shipstern_parser(
     };
 
     let event_parser = if has_events {
-        crate::render::event_parser(&idl.program.name, events, has_instructions)
+        crate::render::event_parser(
+            &idl.program.name,
+            events,
+            has_instructions,
+            config.idl_envelope.as_ref(),
+        )
     } else {
         quote! {}
     };

--- a/docs/codama-parser-generation.md
+++ b/docs/codama-parser-generation.md
@@ -121,3 +121,88 @@ You’ve successfully generated a custom Shipstern parser. It can now be fully i
 - Generated code is idiomatic Rust and integrates directly with shipstern-core.
 
 - Parsers are composable and can be used in a source → parser → sink pipeline for high-throughput indexing.
+
+## Self-CPI events (`emit_cpi!`)
+
+`emit_cpi!` does not write a log line. It invokes the program from itself, with
+instruction data shaped as:
+
+```
+[envelope tag][event discriminator][borsh payload]
+```
+
+Codama has no node for that tag, so Shipstern infers it positionally from the
+event's discriminator chain, the same rule the Carbon renderer uses. Declare two
+or more `constantDiscriminatorNode`s on the event:
+
+```json
+"discriminators": [
+  { "kind": "constantDiscriminatorNode", "offset": 0,
+    "constant": { "kind": "constantValueNode",
+      "type": { "kind": "fixedSizeTypeNode", "size": 8, "type": { "kind": "bytesTypeNode" } },
+      "value": { "kind": "bytesValueNode", "data": "e445a52e51cb9a1d", "encoding": "base16" } } },
+  { "kind": "constantDiscriminatorNode", "offset": 8,
+    "constant": { "kind": "constantValueNode",
+      "type": { "kind": "fixedSizeTypeNode", "size": 8, "type": { "kind": "bytesTypeNode" } },
+      "value": { "kind": "bytesValueNode", "data": "40c6cde8260871e2", "encoding": "base16" } } }
+]
+```
+
+The rules:
+
+- The constant at **offset 0** is the envelope tag.
+- Every remaining constant forms the event's own discriminator.
+- `payload_offset` is `sorted[1].offset`, the declared offset of the next
+  discriminator, not the tag's length. Padded layouts therefore round-trip, and
+  discriminators need not be contiguous.
+- One program has one envelope. Events that declare one must agree on both the
+  tag bytes and the payload offset, or the build fails.
+- An event with a single discriminator declares no envelope. It keeps matching
+  at offset 0 and stays reachable from `emit!` log lines.
+- When no event declares an envelope, Anchor's default 8-byte tag is used.
+
+`e445a52e51cb9a1d` is the little-endian serialisation of
+`sha256("anchor:event")[..8]`, whose natural byte order is `1d9acb512ea545e4`.
+Write the wire bytes, not the digest prefix.
+
+### The envelope must not mask an instruction
+
+The generated parser filters any instruction whose data starts with the envelope
+tag before it dispatches, so an instruction whose discriminator shares a prefix
+with the tag at offset 0 could never be parsed. That is rejected at build time:
+
+    error: Invalid CPI event envelope in "...": CPI event envelope 09 collides
+    with instruction `swapBig` (discriminator 09 at offset 0); the generated
+    parser filters every instruction whose data starts with the envelope tag, so
+    `swapBig` would never parse
+
+The check runs against the tag the parser actually uses, so it covers an IDL
+envelope, the `cpi_event_discriminator` fallback, and the Anchor default alike.
+It compares the tag only against instructions. Instruction variants that
+deliberately share a discriminator with each other, resolved at runtime by
+account count or a `CustomInstructionParser`, are unaffected.
+
+Note this differs from Anchor, whose dispatcher checks the event-CPI sentinel
+after every instruction rather than before.
+
+### Deliberate divergences from Carbon
+
+Both follow from Shipstern supporting `emit!` log events, which Carbon's
+generated decoders do not.
+
+1. **Mixed programs are accepted.** Carbon bails on the whole program if any
+   single event lacks the two-discriminator form; Shipstern accepts a program
+   that mixes `emit_cpi!` and `emit!` events. An IDL Shipstern accepts may
+   therefore render nothing in Carbon.
+2. **A lone two-part discriminator reads as enveloped.** The heuristic is
+   positional and no marker node exists, so an event with a genuine two-part
+   discriminator starting at offset 0 is indistinguishable from
+   envelope-plus-discriminator, and is treated as the latter.
+
+### Macro arguments are deprecated
+
+`cpi_event_discriminator` and `cpi_event_payload_offset` on
+`include_shipstern_parser!` remain as a fallback for IDLs that declare no
+envelope. When the IDL declares one it wins and the arguments are ignored, with
+a deprecation warning at the call site. Both are removed in 0.10; move the
+envelope into the IDL.

--- a/tests/idls/chained_cpi_event_envelope.json
+++ b/tests/idls/chained_cpi_event_envelope.json
@@ -1,0 +1,135 @@
+{
+ "kind": "rootNode",
+ "standard": "codama",
+ "version": "1.0.0",
+ "additionalPrograms": [],
+ "program": {
+  "kind": "programNode",
+  "name": "chainedEnvelope",
+  "publicKey": "11111111111111111111111111111111",
+  "version": "0.1.0",
+  "origin": "anchor",
+  "docs": [],
+  "accounts": [],
+  "definedTypes": [],
+  "pdas": [],
+  "errors": [],
+  "instructions": [
+   {
+    "kind": "instructionNode",
+    "name": "doThing",
+    "docs": [],
+    "optionalAccountStrategy": "programId",
+    "accounts": [],
+    "arguments": [
+     {
+      "kind": "instructionArgumentNode",
+      "name": "discriminator",
+      "defaultValueStrategy": "omitted",
+      "docs": [],
+      "type": {
+       "kind": "fixedSizeTypeNode",
+       "size": 8,
+       "type": {
+        "kind": "bytesTypeNode"
+       }
+      },
+      "defaultValue": {
+       "kind": "bytesValueNode",
+       "data": "0102030405060708",
+       "encoding": "base16"
+      }
+     }
+    ],
+    "discriminators": [
+     {
+      "kind": "fieldDiscriminatorNode",
+      "name": "discriminator",
+      "offset": 0
+     }
+    ]
+   }
+  ],
+  "events": [
+   {
+    "kind": "eventNode",
+    "name": "gammaEvent",
+    "docs": [],
+    "data": {
+     "kind": "structTypeNode",
+     "fields": [
+      {
+       "kind": "structFieldTypeNode",
+       "name": "amount",
+       "docs": [],
+       "type": {
+        "kind": "numberTypeNode",
+        "format": "u64",
+        "endian": "le"
+       }
+      }
+     ]
+    },
+    "discriminators": [
+     {
+      "kind": "constantDiscriminatorNode",
+      "offset": 0,
+      "constant": {
+       "kind": "constantValueNode",
+       "type": {
+        "kind": "fixedSizeTypeNode",
+        "size": 1,
+        "type": {
+         "kind": "bytesTypeNode"
+        }
+       },
+       "value": {
+        "kind": "bytesValueNode",
+        "data": "fe",
+        "encoding": "base16"
+       }
+      }
+     },
+     {
+      "kind": "constantDiscriminatorNode",
+      "offset": 4,
+      "constant": {
+       "kind": "constantValueNode",
+       "type": {
+        "kind": "fixedSizeTypeNode",
+        "size": 2,
+        "type": {
+         "kind": "bytesTypeNode"
+        }
+       },
+       "value": {
+        "kind": "bytesValueNode",
+        "data": "a1a2",
+        "encoding": "base16"
+       }
+      }
+     },
+     {
+      "kind": "constantDiscriminatorNode",
+      "offset": 8,
+      "constant": {
+       "kind": "constantValueNode",
+       "type": {
+        "kind": "fixedSizeTypeNode",
+        "size": 1,
+        "type": {
+         "kind": "bytesTypeNode"
+        }
+       },
+       "value": {
+        "kind": "bytesValueNode",
+        "data": "b7",
+        "encoding": "base16"
+       }
+      }
+     }
+    ]
+   }
+  ]
+ }
+}

--- a/tests/idls/colliding_envelope.json
+++ b/tests/idls/colliding_envelope.json
@@ -1,0 +1,212 @@
+{
+ "kind": "rootNode",
+ "standard": "codama",
+ "version": "1.0.0",
+ "additionalPrograms": [],
+ "program": {
+  "kind": "programNode",
+  "name": "collidingEnvelope",
+  "publicKey": "11111111111111111111111111111111",
+  "version": "0.1.0",
+  "origin": "anchor",
+  "docs": [],
+  "accounts": [],
+  "definedTypes": [],
+  "pdas": [],
+  "errors": [],
+  "instructions": [
+   {
+    "kind": "instructionNode",
+    "name": "swapBig",
+    "docs": [],
+    "optionalAccountStrategy": "programId",
+    "accounts": [
+     {
+      "kind": "instructionAccountNode",
+      "name": "a0",
+      "isWritable": false,
+      "isSigner": false,
+      "isOptional": false,
+      "docs": []
+     },
+     {
+      "kind": "instructionAccountNode",
+      "name": "a1",
+      "isWritable": false,
+      "isSigner": false,
+      "isOptional": false,
+      "docs": []
+     },
+     {
+      "kind": "instructionAccountNode",
+      "name": "a2",
+      "isWritable": false,
+      "isSigner": false,
+      "isOptional": false,
+      "docs": []
+     }
+    ],
+    "arguments": [
+     {
+      "kind": "instructionArgumentNode",
+      "name": "discriminator",
+      "defaultValueStrategy": "omitted",
+      "docs": [],
+      "type": {
+       "kind": "fixedSizeTypeNode",
+       "size": 1,
+       "type": {
+        "kind": "bytesTypeNode"
+       }
+      },
+      "defaultValue": {
+       "kind": "bytesValueNode",
+       "data": "09",
+       "encoding": "base16"
+      }
+     },
+     {
+      "kind": "instructionArgumentNode",
+      "name": "amountIn",
+      "docs": [],
+      "type": {
+       "kind": "numberTypeNode",
+       "format": "u64",
+       "endian": "le"
+      }
+     }
+    ],
+    "discriminators": [
+     {
+      "kind": "fieldDiscriminatorNode",
+      "name": "discriminator",
+      "offset": 0
+     }
+    ]
+   },
+   {
+    "kind": "instructionNode",
+    "name": "swapSmall",
+    "docs": [],
+    "optionalAccountStrategy": "programId",
+    "accounts": [
+     {
+      "kind": "instructionAccountNode",
+      "name": "a0",
+      "isWritable": false,
+      "isSigner": false,
+      "isOptional": false,
+      "docs": []
+     },
+     {
+      "kind": "instructionAccountNode",
+      "name": "a1",
+      "isWritable": false,
+      "isSigner": false,
+      "isOptional": false,
+      "docs": []
+     }
+    ],
+    "arguments": [
+     {
+      "kind": "instructionArgumentNode",
+      "name": "discriminator",
+      "defaultValueStrategy": "omitted",
+      "docs": [],
+      "type": {
+       "kind": "fixedSizeTypeNode",
+       "size": 1,
+       "type": {
+        "kind": "bytesTypeNode"
+       }
+      },
+      "defaultValue": {
+       "kind": "bytesValueNode",
+       "data": "09",
+       "encoding": "base16"
+      }
+     },
+     {
+      "kind": "instructionArgumentNode",
+      "name": "amountIn",
+      "docs": [],
+      "type": {
+       "kind": "numberTypeNode",
+       "format": "u64",
+       "endian": "le"
+      }
+     }
+    ],
+    "discriminators": [
+     {
+      "kind": "fieldDiscriminatorNode",
+      "name": "discriminator",
+      "offset": 0
+     }
+    ]
+   }
+  ],
+  "events": [
+   {
+    "kind": "eventNode",
+    "name": "deltaEvent",
+    "docs": [],
+    "data": {
+     "kind": "structTypeNode",
+     "fields": [
+      {
+       "kind": "structFieldTypeNode",
+       "name": "amount",
+       "docs": [],
+       "type": {
+        "kind": "numberTypeNode",
+        "format": "u64",
+        "endian": "le"
+       }
+      }
+     ]
+    },
+    "discriminators": [
+     {
+      "kind": "constantDiscriminatorNode",
+      "offset": 0,
+      "constant": {
+       "kind": "constantValueNode",
+       "type": {
+        "kind": "fixedSizeTypeNode",
+        "size": 1,
+        "type": {
+         "kind": "bytesTypeNode"
+        }
+       },
+       "value": {
+        "kind": "bytesValueNode",
+        "data": "09",
+        "encoding": "base16"
+       }
+      }
+     },
+     {
+      "kind": "constantDiscriminatorNode",
+      "offset": 1,
+      "constant": {
+       "kind": "constantValueNode",
+       "type": {
+        "kind": "fixedSizeTypeNode",
+        "size": 2,
+        "type": {
+         "kind": "bytesTypeNode"
+        }
+       },
+       "value": {
+        "kind": "bytesValueNode",
+        "data": "d1d2",
+        "encoding": "base16"
+       }
+      }
+     }
+    ]
+   }
+  ]
+ }
+}

--- a/tests/idls/collision_safe_cpi_event_envelope.json
+++ b/tests/idls/collision_safe_cpi_event_envelope.json
@@ -1,0 +1,212 @@
+{
+ "kind": "rootNode",
+ "standard": "codama",
+ "version": "1.0.0",
+ "additionalPrograms": [],
+ "program": {
+  "kind": "programNode",
+  "name": "collisionSafe",
+  "publicKey": "11111111111111111111111111111111",
+  "version": "0.1.0",
+  "origin": "anchor",
+  "docs": [],
+  "accounts": [],
+  "definedTypes": [],
+  "pdas": [],
+  "errors": [],
+  "instructions": [
+   {
+    "kind": "instructionNode",
+    "name": "swapBig",
+    "docs": [],
+    "optionalAccountStrategy": "programId",
+    "accounts": [
+     {
+      "kind": "instructionAccountNode",
+      "name": "a0",
+      "isWritable": false,
+      "isSigner": false,
+      "isOptional": false,
+      "docs": []
+     },
+     {
+      "kind": "instructionAccountNode",
+      "name": "a1",
+      "isWritable": false,
+      "isSigner": false,
+      "isOptional": false,
+      "docs": []
+     },
+     {
+      "kind": "instructionAccountNode",
+      "name": "a2",
+      "isWritable": false,
+      "isSigner": false,
+      "isOptional": false,
+      "docs": []
+     }
+    ],
+    "arguments": [
+     {
+      "kind": "instructionArgumentNode",
+      "name": "discriminator",
+      "defaultValueStrategy": "omitted",
+      "docs": [],
+      "type": {
+       "kind": "fixedSizeTypeNode",
+       "size": 1,
+       "type": {
+        "kind": "bytesTypeNode"
+       }
+      },
+      "defaultValue": {
+       "kind": "bytesValueNode",
+       "data": "09",
+       "encoding": "base16"
+      }
+     },
+     {
+      "kind": "instructionArgumentNode",
+      "name": "amountIn",
+      "docs": [],
+      "type": {
+       "kind": "numberTypeNode",
+       "format": "u64",
+       "endian": "le"
+      }
+     }
+    ],
+    "discriminators": [
+     {
+      "kind": "fieldDiscriminatorNode",
+      "name": "discriminator",
+      "offset": 0
+     }
+    ]
+   },
+   {
+    "kind": "instructionNode",
+    "name": "swapSmall",
+    "docs": [],
+    "optionalAccountStrategy": "programId",
+    "accounts": [
+     {
+      "kind": "instructionAccountNode",
+      "name": "a0",
+      "isWritable": false,
+      "isSigner": false,
+      "isOptional": false,
+      "docs": []
+     },
+     {
+      "kind": "instructionAccountNode",
+      "name": "a1",
+      "isWritable": false,
+      "isSigner": false,
+      "isOptional": false,
+      "docs": []
+     }
+    ],
+    "arguments": [
+     {
+      "kind": "instructionArgumentNode",
+      "name": "discriminator",
+      "defaultValueStrategy": "omitted",
+      "docs": [],
+      "type": {
+       "kind": "fixedSizeTypeNode",
+       "size": 1,
+       "type": {
+        "kind": "bytesTypeNode"
+       }
+      },
+      "defaultValue": {
+       "kind": "bytesValueNode",
+       "data": "09",
+       "encoding": "base16"
+      }
+     },
+     {
+      "kind": "instructionArgumentNode",
+      "name": "amountIn",
+      "docs": [],
+      "type": {
+       "kind": "numberTypeNode",
+       "format": "u64",
+       "endian": "le"
+      }
+     }
+    ],
+    "discriminators": [
+     {
+      "kind": "fieldDiscriminatorNode",
+      "name": "discriminator",
+      "offset": 0
+     }
+    ]
+   }
+  ],
+  "events": [
+   {
+    "kind": "eventNode",
+    "name": "deltaEvent",
+    "docs": [],
+    "data": {
+     "kind": "structTypeNode",
+     "fields": [
+      {
+       "kind": "structFieldTypeNode",
+       "name": "amount",
+       "docs": [],
+       "type": {
+        "kind": "numberTypeNode",
+        "format": "u64",
+        "endian": "le"
+       }
+      }
+     ]
+    },
+    "discriminators": [
+     {
+      "kind": "constantDiscriminatorNode",
+      "offset": 0,
+      "constant": {
+       "kind": "constantValueNode",
+       "type": {
+        "kind": "fixedSizeTypeNode",
+        "size": 1,
+        "type": {
+         "kind": "bytesTypeNode"
+        }
+       },
+       "value": {
+        "kind": "bytesValueNode",
+        "data": "fe",
+        "encoding": "base16"
+       }
+      }
+     },
+     {
+      "kind": "constantDiscriminatorNode",
+      "offset": 1,
+      "constant": {
+       "kind": "constantValueNode",
+       "type": {
+        "kind": "fixedSizeTypeNode",
+        "size": 2,
+        "type": {
+         "kind": "bytesTypeNode"
+        }
+       },
+       "value": {
+        "kind": "bytesValueNode",
+        "data": "d1d2",
+        "encoding": "base16"
+       }
+      }
+     }
+    ]
+   }
+  ]
+ }
+}

--- a/tests/idls/macro_arg_envelope_collision.json
+++ b/tests/idls/macro_arg_envelope_collision.json
@@ -1,0 +1,193 @@
+{
+ "kind": "rootNode",
+ "standard": "codama",
+ "version": "1.0.0",
+ "additionalPrograms": [],
+ "program": {
+  "kind": "programNode",
+  "name": "macroArgEnvelope",
+  "publicKey": "11111111111111111111111111111111",
+  "version": "0.1.0",
+  "origin": "anchor",
+  "docs": [],
+  "accounts": [],
+  "definedTypes": [],
+  "pdas": [],
+  "errors": [],
+  "instructions": [
+   {
+    "kind": "instructionNode",
+    "name": "swapBig",
+    "docs": [],
+    "optionalAccountStrategy": "programId",
+    "accounts": [
+     {
+      "kind": "instructionAccountNode",
+      "name": "a0",
+      "isWritable": false,
+      "isSigner": false,
+      "isOptional": false,
+      "docs": []
+     },
+     {
+      "kind": "instructionAccountNode",
+      "name": "a1",
+      "isWritable": false,
+      "isSigner": false,
+      "isOptional": false,
+      "docs": []
+     },
+     {
+      "kind": "instructionAccountNode",
+      "name": "a2",
+      "isWritable": false,
+      "isSigner": false,
+      "isOptional": false,
+      "docs": []
+     }
+    ],
+    "arguments": [
+     {
+      "kind": "instructionArgumentNode",
+      "name": "discriminator",
+      "defaultValueStrategy": "omitted",
+      "docs": [],
+      "type": {
+       "kind": "fixedSizeTypeNode",
+       "size": 1,
+       "type": {
+        "kind": "bytesTypeNode"
+       }
+      },
+      "defaultValue": {
+       "kind": "bytesValueNode",
+       "data": "09",
+       "encoding": "base16"
+      }
+     },
+     {
+      "kind": "instructionArgumentNode",
+      "name": "amountIn",
+      "docs": [],
+      "type": {
+       "kind": "numberTypeNode",
+       "format": "u64",
+       "endian": "le"
+      }
+     }
+    ],
+    "discriminators": [
+     {
+      "kind": "fieldDiscriminatorNode",
+      "name": "discriminator",
+      "offset": 0
+     }
+    ]
+   },
+   {
+    "kind": "instructionNode",
+    "name": "swapSmall",
+    "docs": [],
+    "optionalAccountStrategy": "programId",
+    "accounts": [
+     {
+      "kind": "instructionAccountNode",
+      "name": "a0",
+      "isWritable": false,
+      "isSigner": false,
+      "isOptional": false,
+      "docs": []
+     },
+     {
+      "kind": "instructionAccountNode",
+      "name": "a1",
+      "isWritable": false,
+      "isSigner": false,
+      "isOptional": false,
+      "docs": []
+     }
+    ],
+    "arguments": [
+     {
+      "kind": "instructionArgumentNode",
+      "name": "discriminator",
+      "defaultValueStrategy": "omitted",
+      "docs": [],
+      "type": {
+       "kind": "fixedSizeTypeNode",
+       "size": 1,
+       "type": {
+        "kind": "bytesTypeNode"
+       }
+      },
+      "defaultValue": {
+       "kind": "bytesValueNode",
+       "data": "09",
+       "encoding": "base16"
+      }
+     },
+     {
+      "kind": "instructionArgumentNode",
+      "name": "amountIn",
+      "docs": [],
+      "type": {
+       "kind": "numberTypeNode",
+       "format": "u64",
+       "endian": "le"
+      }
+     }
+    ],
+    "discriminators": [
+     {
+      "kind": "fieldDiscriminatorNode",
+      "name": "discriminator",
+      "offset": 0
+     }
+    ]
+   }
+  ],
+  "events": [
+   {
+    "kind": "eventNode",
+    "name": "deltaEvent",
+    "docs": [],
+    "data": {
+     "kind": "structTypeNode",
+     "fields": [
+      {
+       "kind": "structFieldTypeNode",
+       "name": "amount",
+       "docs": [],
+       "type": {
+        "kind": "numberTypeNode",
+        "format": "u64",
+        "endian": "le"
+       }
+      }
+     ]
+    },
+    "discriminators": [
+     {
+      "kind": "constantDiscriminatorNode",
+      "offset": 0,
+      "constant": {
+       "kind": "constantValueNode",
+       "type": {
+        "kind": "fixedSizeTypeNode",
+        "size": 2,
+        "type": {
+         "kind": "bytesTypeNode"
+        }
+       },
+       "value": {
+        "kind": "bytesValueNode",
+        "data": "d1d2",
+        "encoding": "base16"
+       }
+      }
+     }
+    ]
+   }
+  ]
+ }
+}

--- a/tests/idls/malformed_envelope_discriminator.json
+++ b/tests/idls/malformed_envelope_discriminator.json
@@ -1,0 +1,116 @@
+{
+ "kind": "rootNode",
+ "standard": "codama",
+ "version": "1.0.0",
+ "program": {
+  "kind": "programNode",
+  "name": "malformedEnvelope",
+  "publicKey": "11111111111111111111111111111111",
+  "version": "0.1.0",
+  "origin": "anchor",
+  "docs": [],
+  "accounts": [],
+  "definedTypes": [],
+  "pdas": [],
+  "errors": [],
+  "instructions": [
+   {
+    "kind": "instructionNode",
+    "name": "doThing",
+    "docs": [],
+    "optionalAccountStrategy": "programId",
+    "accounts": [],
+    "arguments": [
+     {
+      "kind": "instructionArgumentNode",
+      "name": "discriminator",
+      "defaultValueStrategy": "omitted",
+      "docs": [],
+      "type": {
+       "kind": "fixedSizeTypeNode",
+       "size": 8,
+       "type": {
+        "kind": "bytesTypeNode"
+       }
+      },
+      "defaultValue": {
+       "kind": "bytesValueNode",
+       "data": "0102030405060708",
+       "encoding": "base16"
+      }
+     }
+    ],
+    "discriminators": [
+     {
+      "kind": "fieldDiscriminatorNode",
+      "name": "discriminator",
+      "offset": 0
+     }
+    ]
+   }
+  ],
+  "events": [
+   {
+    "kind": "eventNode",
+    "name": "alphaEvent",
+    "docs": [],
+    "data": {
+     "kind": "structTypeNode",
+     "fields": [
+      {
+       "kind": "structFieldTypeNode",
+       "name": "amount",
+       "docs": [],
+       "type": {
+        "kind": "numberTypeNode",
+        "format": "u64",
+        "endian": "le"
+       }
+      }
+     ]
+    },
+    "discriminators": [
+     {
+      "kind": "constantDiscriminatorNode",
+      "offset": 0,
+      "constant": {
+       "kind": "constantValueNode",
+       "type": {
+        "kind": "fixedSizeTypeNode",
+        "size": 1,
+        "type": {
+         "kind": "bytesTypeNode"
+        }
+       },
+       "value": {
+        "kind": "bytesValueNode",
+        "data": "zz",
+        "encoding": "base16"
+       }
+      }
+     },
+     {
+      "kind": "constantDiscriminatorNode",
+      "offset": 4,
+      "constant": {
+       "kind": "constantValueNode",
+       "type": {
+        "kind": "fixedSizeTypeNode",
+        "size": 2,
+        "type": {
+         "kind": "bytesTypeNode"
+        }
+       },
+       "value": {
+        "kind": "bytesValueNode",
+        "data": "a1a2",
+        "encoding": "base16"
+       }
+      }
+     }
+    ]
+   }
+  ]
+ },
+ "additionalPrograms": []
+}

--- a/tests/idls/mismatched_payload_offsets.json
+++ b/tests/idls/mismatched_payload_offsets.json
@@ -1,0 +1,176 @@
+{
+ "kind": "rootNode",
+ "standard": "codama",
+ "version": "1.0.0",
+ "program": {
+  "kind": "programNode",
+  "name": "mismatchedOffsets",
+  "publicKey": "11111111111111111111111111111111",
+  "version": "0.1.0",
+  "origin": "anchor",
+  "docs": [],
+  "accounts": [],
+  "definedTypes": [],
+  "pdas": [],
+  "errors": [],
+  "instructions": [
+   {
+    "kind": "instructionNode",
+    "name": "doThing",
+    "docs": [],
+    "optionalAccountStrategy": "programId",
+    "accounts": [],
+    "arguments": [
+     {
+      "kind": "instructionArgumentNode",
+      "name": "discriminator",
+      "defaultValueStrategy": "omitted",
+      "docs": [],
+      "type": {
+       "kind": "fixedSizeTypeNode",
+       "size": 8,
+       "type": {
+        "kind": "bytesTypeNode"
+       }
+      },
+      "defaultValue": {
+       "kind": "bytesValueNode",
+       "data": "0102030405060708",
+       "encoding": "base16"
+      }
+     }
+    ],
+    "discriminators": [
+     {
+      "kind": "fieldDiscriminatorNode",
+      "name": "discriminator",
+      "offset": 0
+     }
+    ]
+   }
+  ],
+  "events": [
+   {
+    "kind": "eventNode",
+    "name": "alphaEvent",
+    "docs": [],
+    "data": {
+     "kind": "structTypeNode",
+     "fields": [
+      {
+       "kind": "structFieldTypeNode",
+       "name": "amount",
+       "docs": [],
+       "type": {
+        "kind": "numberTypeNode",
+        "format": "u64",
+        "endian": "le"
+       }
+      }
+     ]
+    },
+    "discriminators": [
+     {
+      "kind": "constantDiscriminatorNode",
+      "offset": 0,
+      "constant": {
+       "kind": "constantValueNode",
+       "type": {
+        "kind": "fixedSizeTypeNode",
+        "size": 1,
+        "type": {
+         "kind": "bytesTypeNode"
+        }
+       },
+       "value": {
+        "kind": "bytesValueNode",
+        "data": "fe",
+        "encoding": "base16"
+       }
+      }
+     },
+     {
+      "kind": "constantDiscriminatorNode",
+      "offset": 4,
+      "constant": {
+       "kind": "constantValueNode",
+       "type": {
+        "kind": "fixedSizeTypeNode",
+        "size": 2,
+        "type": {
+         "kind": "bytesTypeNode"
+        }
+       },
+       "value": {
+        "kind": "bytesValueNode",
+        "data": "a1a2",
+        "encoding": "base16"
+       }
+      }
+     }
+    ]
+   },
+   {
+    "kind": "eventNode",
+    "name": "alphaTwoEvent",
+    "docs": [],
+    "data": {
+     "kind": "structTypeNode",
+     "fields": [
+      {
+       "kind": "structFieldTypeNode",
+       "name": "amount",
+       "docs": [],
+       "type": {
+        "kind": "numberTypeNode",
+        "format": "u64",
+        "endian": "le"
+       }
+      }
+     ]
+    },
+    "discriminators": [
+     {
+      "kind": "constantDiscriminatorNode",
+      "offset": 0,
+      "constant": {
+       "kind": "constantValueNode",
+       "type": {
+        "kind": "fixedSizeTypeNode",
+        "size": 1,
+        "type": {
+         "kind": "bytesTypeNode"
+        }
+       },
+       "value": {
+        "kind": "bytesValueNode",
+        "data": "fe",
+        "encoding": "base16"
+       }
+      }
+     },
+     {
+      "kind": "constantDiscriminatorNode",
+      "offset": 6,
+      "constant": {
+       "kind": "constantValueNode",
+       "type": {
+        "kind": "fixedSizeTypeNode",
+        "size": 2,
+        "type": {
+         "kind": "bytesTypeNode"
+        }
+       },
+       "value": {
+        "kind": "bytesValueNode",
+        "data": "b1b2",
+        "encoding": "base16"
+       }
+      }
+     }
+    ]
+   }
+  ]
+ },
+ "additionalPrograms": []
+}

--- a/tests/idls/multi_discriminator_instruction.json
+++ b/tests/idls/multi_discriminator_instruction.json
@@ -1,0 +1,150 @@
+{
+ "kind": "rootNode",
+ "standard": "codama",
+ "version": "1.0.0",
+ "additionalPrograms": [],
+ "program": {
+  "kind": "programNode",
+  "name": "multiDiscInstruction",
+  "publicKey": "11111111111111111111111111111111",
+  "version": "0.1.0",
+  "origin": "anchor",
+  "docs": [],
+  "accounts": [],
+  "definedTypes": [],
+  "pdas": [],
+  "errors": [],
+  "instructions": [
+   {
+    "kind": "instructionNode",
+    "name": "doubleTagged",
+    "docs": [],
+    "optionalAccountStrategy": "programId",
+    "accounts": [
+     {
+      "kind": "instructionAccountNode",
+      "name": "a0",
+      "isWritable": false,
+      "isSigner": false,
+      "isOptional": false,
+      "docs": []
+     }
+    ],
+    "arguments": [
+     {
+      "kind": "instructionArgumentNode",
+      "name": "amountIn",
+      "docs": [],
+      "type": {
+       "kind": "numberTypeNode",
+       "format": "u64",
+       "endian": "le"
+      }
+     }
+    ],
+    "discriminators": [
+     {
+      "kind": "constantDiscriminatorNode",
+      "offset": 0,
+      "constant": {
+       "kind": "constantValueNode",
+       "type": {
+        "kind": "fixedSizeTypeNode",
+        "size": 1,
+        "type": {
+         "kind": "bytesTypeNode"
+        }
+       },
+       "value": {
+        "kind": "bytesValueNode",
+        "data": "aa",
+        "encoding": "base16"
+       }
+      }
+     },
+     {
+      "kind": "constantDiscriminatorNode",
+      "offset": 4,
+      "constant": {
+       "kind": "constantValueNode",
+       "type": {
+        "kind": "fixedSizeTypeNode",
+        "size": 1,
+        "type": {
+         "kind": "bytesTypeNode"
+        }
+       },
+       "value": {
+        "kind": "bytesValueNode",
+        "data": "bb",
+        "encoding": "base16"
+       }
+      }
+     }
+    ]
+   }
+  ],
+  "events": [
+   {
+    "kind": "eventNode",
+    "name": "zetaEvent",
+    "docs": [],
+    "data": {
+     "kind": "structTypeNode",
+     "fields": [
+      {
+       "kind": "structFieldTypeNode",
+       "name": "amount",
+       "docs": [],
+       "type": {
+        "kind": "numberTypeNode",
+        "format": "u64",
+        "endian": "le"
+       }
+      }
+     ]
+    },
+    "discriminators": [
+     {
+      "kind": "constantDiscriminatorNode",
+      "offset": 0,
+      "constant": {
+       "kind": "constantValueNode",
+       "type": {
+        "kind": "fixedSizeTypeNode",
+        "size": 1,
+        "type": {
+         "kind": "bytesTypeNode"
+        }
+       },
+       "value": {
+        "kind": "bytesValueNode",
+        "data": "fe",
+        "encoding": "base16"
+       }
+      }
+     },
+     {
+      "kind": "constantDiscriminatorNode",
+      "offset": 1,
+      "constant": {
+       "kind": "constantValueNode",
+       "type": {
+        "kind": "fixedSizeTypeNode",
+        "size": 2,
+        "type": {
+         "kind": "bytesTypeNode"
+        }
+       },
+       "value": {
+        "kind": "bytesValueNode",
+        "data": "f1f2",
+        "encoding": "base16"
+       }
+      }
+     }
+    ]
+   }
+  ]
+ }
+}

--- a/tests/idls/padded_cpi_event_envelope.json
+++ b/tests/idls/padded_cpi_event_envelope.json
@@ -1,0 +1,116 @@
+{
+ "kind": "rootNode",
+ "standard": "codama",
+ "version": "1.0.0",
+ "program": {
+  "kind": "programNode",
+  "name": "paddedEnvelope",
+  "publicKey": "11111111111111111111111111111111",
+  "version": "0.1.0",
+  "origin": "anchor",
+  "docs": [],
+  "accounts": [],
+  "definedTypes": [],
+  "pdas": [],
+  "errors": [],
+  "instructions": [
+   {
+    "kind": "instructionNode",
+    "name": "doThing",
+    "docs": [],
+    "optionalAccountStrategy": "programId",
+    "accounts": [],
+    "arguments": [
+     {
+      "kind": "instructionArgumentNode",
+      "name": "discriminator",
+      "defaultValueStrategy": "omitted",
+      "docs": [],
+      "type": {
+       "kind": "fixedSizeTypeNode",
+       "size": 8,
+       "type": {
+        "kind": "bytesTypeNode"
+       }
+      },
+      "defaultValue": {
+       "kind": "bytesValueNode",
+       "data": "0102030405060708",
+       "encoding": "base16"
+      }
+     }
+    ],
+    "discriminators": [
+     {
+      "kind": "fieldDiscriminatorNode",
+      "name": "discriminator",
+      "offset": 0
+     }
+    ]
+   }
+  ],
+  "events": [
+   {
+    "kind": "eventNode",
+    "name": "alphaEvent",
+    "docs": [],
+    "data": {
+     "kind": "structTypeNode",
+     "fields": [
+      {
+       "kind": "structFieldTypeNode",
+       "name": "amount",
+       "docs": [],
+       "type": {
+        "kind": "numberTypeNode",
+        "format": "u64",
+        "endian": "le"
+       }
+      }
+     ]
+    },
+    "discriminators": [
+     {
+      "kind": "constantDiscriminatorNode",
+      "offset": 0,
+      "constant": {
+       "kind": "constantValueNode",
+       "type": {
+        "kind": "fixedSizeTypeNode",
+        "size": 1,
+        "type": {
+         "kind": "bytesTypeNode"
+        }
+       },
+       "value": {
+        "kind": "bytesValueNode",
+        "data": "fe",
+        "encoding": "base16"
+       }
+      }
+     },
+     {
+      "kind": "constantDiscriminatorNode",
+      "offset": 4,
+      "constant": {
+       "kind": "constantValueNode",
+       "type": {
+        "kind": "fixedSizeTypeNode",
+        "size": 2,
+        "type": {
+         "kind": "bytesTypeNode"
+        }
+       },
+       "value": {
+        "kind": "bytesValueNode",
+        "data": "a1a2",
+        "encoding": "base16"
+       }
+      }
+     }
+    ]
+   }
+  ]
+ },
+ "additionalPrograms": []
+}

--- a/tests/idls/single_discriminator_event.json
+++ b/tests/idls/single_discriminator_event.json
@@ -1,0 +1,97 @@
+{
+ "kind": "rootNode",
+ "standard": "codama",
+ "version": "1.0.0",
+ "program": {
+  "kind": "programNode",
+  "name": "plainEnvelope",
+  "publicKey": "11111111111111111111111111111111",
+  "version": "0.1.0",
+  "origin": "anchor",
+  "docs": [],
+  "accounts": [],
+  "definedTypes": [],
+  "pdas": [],
+  "errors": [],
+  "instructions": [
+   {
+    "kind": "instructionNode",
+    "name": "doThing",
+    "docs": [],
+    "optionalAccountStrategy": "programId",
+    "accounts": [],
+    "arguments": [
+     {
+      "kind": "instructionArgumentNode",
+      "name": "discriminator",
+      "defaultValueStrategy": "omitted",
+      "docs": [],
+      "type": {
+       "kind": "fixedSizeTypeNode",
+       "size": 8,
+       "type": {
+        "kind": "bytesTypeNode"
+       }
+      },
+      "defaultValue": {
+       "kind": "bytesValueNode",
+       "data": "0102030405060708",
+       "encoding": "base16"
+      }
+     }
+    ],
+    "discriminators": [
+     {
+      "kind": "fieldDiscriminatorNode",
+      "name": "discriminator",
+      "offset": 0
+     }
+    ]
+   }
+  ],
+  "events": [
+   {
+    "kind": "eventNode",
+    "name": "epsilonEvent",
+    "docs": [],
+    "data": {
+     "kind": "structTypeNode",
+     "fields": [
+      {
+       "kind": "structFieldTypeNode",
+       "name": "amount",
+       "docs": [],
+       "type": {
+        "kind": "numberTypeNode",
+        "format": "u64",
+        "endian": "le"
+       }
+      }
+     ]
+    },
+    "discriminators": [
+     {
+      "kind": "constantDiscriminatorNode",
+      "offset": 0,
+      "constant": {
+       "kind": "constantValueNode",
+       "type": {
+        "kind": "fixedSizeTypeNode",
+        "size": 2,
+        "type": {
+         "kind": "bytesTypeNode"
+        }
+       },
+       "value": {
+        "kind": "bytesValueNode",
+        "data": "e1e2",
+        "encoding": "base16"
+       }
+      }
+     }
+    ]
+   }
+  ]
+ },
+ "additionalPrograms": []
+}

--- a/tests/proc-macro-events/tests/chained_cpi_event_envelope.rs
+++ b/tests/proc-macro-events/tests/chained_cpi_event_envelope.rs
@@ -1,0 +1,146 @@
+//!
+//! Coverage for an event whose discriminator chain has more than two links and
+//! a real gap between them.
+//!
+//! The IDL declares envelope `fe`@0, then `a1a2`@4 and `b7`@8, so
+//! `payload_offset` is 4 and the rebased layout is `a1a2`@0, a two-byte gap,
+//! `b7`@4. The payload therefore begins at rebased offset 5, after the last
+//! discriminator, not after the first, which a contiguous layout would put at 2.
+//!
+//! The gap bytes are `cc cc` rather than zeroes so that reading the payload from
+//! any wrong offset decodes to a different `u64` instead of a plausible one.
+//!
+
+use std::sync::Arc;
+
+use shipstern_core::{
+    instruction::{InstructionShared, InstructionUpdate, Path},
+    Parser, Pubkey,
+};
+use shipstern_proc_macro::include_shipstern_parser;
+
+include_shipstern_parser!("../idls/chained_cpi_event_envelope.json");
+
+/// `fe` envelope, three pad bytes, `a1a2`, two gap bytes, `b7`.
+const ENVELOPE_AND_CHAIN: [u8; 9] = [0xfe, 0x00, 0x00, 0x00, 0xa1, 0xa2, 0xcc, 0xcc, 0xb7];
+
+/// Rebased offset the payload must be read from: after `b7`, not after `a1a2`.
+const EXPECTED_PAYLOAD_OFFSET: usize = 5;
+
+const AMOUNT: u64 = 0x0102_0304_0506_0708;
+
+fn program_id() -> Pubkey { Pubkey::new(chained_envelope::PROGRAM_ID) }
+
+fn update_with_cpi_event(event_data: Vec<u8>) -> InstructionUpdate {
+    let shared = Arc::new(InstructionShared::default());
+
+    let inner = InstructionUpdate {
+        program: program_id(),
+        accounts: vec![],
+        data: event_data,
+        shared: Arc::clone(&shared),
+        inner: vec![],
+        path: Path::new_single(0),
+        log_range: 0..0,
+    };
+
+    InstructionUpdate {
+        program: program_id(),
+        accounts: vec![],
+        data: vec![1, 2, 3, 4, 5, 6, 7, 8],
+        shared,
+        inner: vec![inner],
+        path: Path::new_single(0),
+        log_range: 0..0,
+    }
+}
+
+///
+/// Every link in the chain must be checked, and the payload read after the last.
+///
+/// The assertion pins the payload's byte position: `AMOUNT` only decodes
+/// correctly when deserialization starts at rebased offset 5. Starting at 2,
+/// where a contiguous chain would put it, yields `0xcc_cc_b7_...` instead.
+///
+#[tokio::test]
+async fn chain_reads_payload_after_last_discriminator() {
+    let mut data = ENVELOPE_AND_CHAIN.to_vec();
+    data.extend_from_slice(&AMOUNT.to_le_bytes());
+
+    // Guard the fixture itself: the payload must sit where the test claims.
+    let payload_offset_in_stripped = ENVELOPE_AND_CHAIN.len() - 4;
+    assert_eq!(
+        payload_offset_in_stripped, EXPECTED_PAYLOAD_OFFSET,
+        "fixture layout drifted from the offset under test",
+    );
+
+    let parser = chained_envelope::InstructionParser;
+    let output = parser
+        .parse(&update_with_cpi_event(data))
+        .await
+        .expect("chained CPI event should parse");
+
+    assert_eq!(output.program_events.len(), 1);
+
+    let chained_envelope::event::Event::GammaEvent { args, .. } = &output.program_events[0].event;
+
+    assert_eq!(
+        args.amount, AMOUNT,
+        "payload must be read from rebased offset {EXPECTED_PAYLOAD_OFFSET}",
+    );
+}
+
+///
+/// A trailing discriminator that does not match must reject the event.
+///
+/// Without the `&&` chain only `a1a2` would be checked, so this buffer, which
+/// differs by a single byte at the `b7` position, would parse and hand back a
+/// wrong payload.
+///
+#[tokio::test]
+async fn chain_rejects_when_trailing_discriminator_differs() {
+    let mut chain = ENVELOPE_AND_CHAIN;
+    chain[8] = 0xb8;
+
+    let mut data = chain.to_vec();
+    data.extend_from_slice(&AMOUNT.to_le_bytes());
+
+    let parser = chained_envelope::InstructionParser;
+    let output = parser
+        .parse(&update_with_cpi_event(data))
+        .await
+        .expect("instruction itself still parses");
+
+    assert!(
+        output.program_events.is_empty(),
+        "a mismatched trailing discriminator must not yield an event",
+    );
+}
+
+///
+/// The same chain, minus the envelope, must match on the log path.
+///
+#[test]
+fn chain_matches_on_log_path() {
+    use base64::Engine;
+
+    let mut data = ENVELOPE_AND_CHAIN[4..].to_vec();
+    data.extend_from_slice(&AMOUNT.to_le_bytes());
+
+    let encoded = base64::engine::general_purpose::STANDARD.encode(&data);
+
+    let program = program_id().to_string();
+    let logs = vec![
+        format!("Program {program} invoke [1]"),
+        format!("Program data: {encoded}"),
+        format!("Program {program} success"),
+    ];
+
+    let events = chained_envelope::resolve_events_from_logs(&logs);
+
+    assert_eq!(events.len(), 1);
+
+    let chained_envelope::event::Event::GammaEvent { args, .. } = &events[0].event;
+
+    assert_eq!(args.amount, AMOUNT);
+}

--- a/tests/proc-macro-events/tests/collision_safe_cpi_event_envelope.rs
+++ b/tests/proc-macro-events/tests/collision_safe_cpi_event_envelope.rs
@@ -1,0 +1,125 @@
+//!
+//! The envelope-vs-instruction collision guard must not disturb the
+//! instruction-vs-instruction disambiguation the README documents.
+//!
+//! This IDL has both in play at once: `swapBig` and `swapSmall` deliberately
+//! share discriminator `0x09` and are told apart by account count, while the
+//! events declare a `0xfe` envelope. The guard runs, since an envelope is
+//! present, and must stay silent because `0xfe` and `0x09` share no prefix.
+//!
+//! Building this file at all is half the assertion: a guard that fired on
+//! instruction-vs-instruction sharing would fail compilation here.
+//!
+
+use std::sync::Arc;
+
+use shipstern_core::{
+    instruction::{InstructionShared, InstructionUpdate, Path},
+    Parser, Pubkey,
+};
+use shipstern_proc_macro::include_shipstern_parser;
+
+include_shipstern_parser!("../idls/collision_safe_cpi_event_envelope.json");
+
+const AMOUNT_IN: u64 = 4_242;
+
+fn program_id() -> Pubkey { Pubkey::new(collision_safe::PROGRAM_ID) }
+
+/// `0x09` discriminator followed by the borsh `amountIn`.
+fn swap_data() -> Vec<u8> {
+    let mut data = vec![0x09];
+    data.extend_from_slice(&AMOUNT_IN.to_le_bytes());
+    data
+}
+
+fn swap_update(account_count: usize) -> InstructionUpdate {
+    InstructionUpdate {
+        program: program_id(),
+        accounts: vec![program_id(); account_count],
+        data: swap_data(),
+        shared: Arc::new(InstructionShared::default()),
+        inner: vec![],
+        path: Path::new_single(0),
+        log_range: 0..0,
+    }
+}
+
+/// Three accounts must route to the larger variant, highest count first.
+#[tokio::test]
+async fn shared_discriminator_resolves_to_the_wider_variant() {
+    let parser = collision_safe::InstructionParser;
+    let output = parser
+        .parse(&swap_update(3))
+        .await
+        .expect("swapBig should parse");
+
+    let instruction = output.instruction.expect("an instruction was parsed");
+
+    assert!(
+        matches!(
+            instruction.instruction,
+            collision_safe::instruction::Instruction::SwapBig { .. }
+        ),
+        "expected SwapBig, got {:?}",
+        instruction.instruction,
+    );
+}
+
+/// Two accounts must fall back to the narrower variant.
+#[tokio::test]
+async fn shared_discriminator_falls_back_to_the_narrower_variant() {
+    let parser = collision_safe::InstructionParser;
+    let output = parser
+        .parse(&swap_update(2))
+        .await
+        .expect("swapSmall should parse");
+
+    let instruction = output.instruction.expect("an instruction was parsed");
+
+    assert!(
+        matches!(
+            instruction.instruction,
+            collision_safe::instruction::Instruction::SwapSmall { .. }
+        ),
+        "expected SwapSmall, got {:?}",
+        instruction.instruction,
+    );
+}
+
+/// The envelope is live in this program, so the guard genuinely ran.
+#[tokio::test]
+async fn envelope_still_parses_events() {
+    let mut event_data = vec![0xfe, 0xd1, 0xd2];
+    event_data.extend_from_slice(&AMOUNT_IN.to_le_bytes());
+
+    let shared = Arc::new(InstructionShared::default());
+
+    let inner = InstructionUpdate {
+        program: program_id(),
+        accounts: vec![],
+        data: event_data,
+        shared: Arc::clone(&shared),
+        inner: vec![],
+        path: Path::new_single(0),
+        log_range: 0..0,
+    };
+
+    let update = InstructionUpdate {
+        program: program_id(),
+        accounts: vec![program_id(); 2],
+        data: swap_data(),
+        shared,
+        inner: vec![inner],
+        path: Path::new_single(0),
+        log_range: 0..0,
+    };
+
+    let parser = collision_safe::InstructionParser;
+    let output = parser.parse(&update).await.expect("should parse");
+
+    assert_eq!(output.program_events.len(), 1);
+
+    let collision_safe::event::Event::DeltaEvent { args, .. } = &output.program_events[0].event;
+
+    assert_eq!(args.amount, AMOUNT_IN);
+}

--- a/tests/proc-macro-events/tests/multi_discriminator_instruction.rs
+++ b/tests/proc-macro-events/tests/multi_discriminator_instruction.rs
@@ -1,0 +1,98 @@
+//!
+//! Instructions must keep keying on their *first* discriminator only.
+//!
+//! The event-side chain logic added for CPI envelopes lives entirely in
+//! `extract_event_discriminator_{key,info}`; the shared privates that
+//! instructions go through still read `discriminators.first()`. This IDL puts
+//! both in one program: `doubleTagged` declares two constant discriminators and
+//! the events declare a `0xfe` envelope, so a chain leaking into the instruction
+//! path would change the result here.
+//!
+
+use std::sync::Arc;
+
+use shipstern_core::{
+    instruction::{InstructionShared, InstructionUpdate, Path},
+    Parser, Pubkey,
+};
+use shipstern_proc_macro::include_shipstern_parser;
+
+include_shipstern_parser!("../idls/multi_discriminator_instruction.json");
+
+/// Byte 3 of the little-endian encoding is `0x00`, so offset 4 of the
+/// instruction data is not `0xbb`, the second declared discriminator.
+const AMOUNT_IN: u64 = 4_242;
+
+fn program_id() -> Pubkey { Pubkey::new(multi_disc_instruction::PROGRAM_ID) }
+
+fn instruction_update(inner: Vec<InstructionUpdate>) -> InstructionUpdate {
+    let mut data = vec![0xaa];
+    data.extend_from_slice(&AMOUNT_IN.to_le_bytes());
+
+    debug_assert_ne!(data[4], 0xbb, "fixture must not accidentally satisfy bb@4");
+
+    InstructionUpdate {
+        program: program_id(),
+        accounts: vec![program_id()],
+        data,
+        shared: Arc::new(InstructionShared::default()),
+        inner,
+        path: Path::new_single(0),
+        log_range: 0..0,
+    }
+}
+
+///
+/// Only the first discriminator gates the instruction.
+///
+/// The IDL declares `aa`@0 and `bb`@4, but the payload puts `0x00` at offset 4.
+/// The instruction must still parse: were the event-side `&&` chain applied to
+/// instructions, this would be filtered instead.
+///
+#[tokio::test]
+async fn instruction_keys_on_first_discriminator_only() {
+    let parser = multi_disc_instruction::InstructionParser;
+    let output = parser
+        .parse(&instruction_update(vec![]))
+        .await
+        .expect("instruction should parse on its first discriminator");
+
+    let instruction = output.instruction.expect("an instruction was parsed");
+
+    let multi_disc_instruction::instruction::Instruction::DoubleTagged { args, .. } =
+        instruction.instruction;
+
+    assert_eq!(args.amount_in, AMOUNT_IN);
+}
+
+/// The envelope is live in the same program, so both paths are exercised.
+#[tokio::test]
+async fn enveloped_event_still_parses_alongside() {
+    let mut event_data = vec![0xfe, 0xf1, 0xf2];
+    event_data.extend_from_slice(&AMOUNT_IN.to_le_bytes());
+
+    let shared = Arc::new(InstructionShared::default());
+
+    let inner = InstructionUpdate {
+        program: program_id(),
+        accounts: vec![],
+        data: event_data,
+        shared: Arc::clone(&shared),
+        inner: vec![],
+        path: Path::new_single(0),
+        log_range: 0..0,
+    };
+
+    let parser = multi_disc_instruction::InstructionParser;
+    let output = parser
+        .parse(&instruction_update(vec![inner]))
+        .await
+        .expect("should parse");
+
+    assert_eq!(output.program_events.len(), 1);
+
+    let multi_disc_instruction::event::Event::ZetaEvent { args, .. } =
+        &output.program_events[0].event;
+
+    assert_eq!(args.amount, AMOUNT_IN);
+}

--- a/tests/proc-macro-events/tests/padded_cpi_event_envelope.rs
+++ b/tests/proc-macro-events/tests/padded_cpi_event_envelope.rs
@@ -1,0 +1,115 @@
+//!
+//! Regression coverage for a CPI event envelope that pads between the envelope
+//! tag and the event discriminator.
+//!
+//! The IDL declares a 1-byte envelope `fe` at offset 0 and the event
+//! discriminator `a1a2` at offset 4, so `payload_offset` is 4. Before the
+//! envelope was sourced from the IDL, the generated parser stripped a fixed 8
+//! bytes, landing 4 bytes inside the borsh payload; both tests below failed.
+//!
+
+use std::sync::Arc;
+
+use shipstern_core::{
+    instruction::{InstructionShared, InstructionUpdate, Path},
+    Parser, Pubkey,
+};
+use shipstern_proc_macro::include_shipstern_parser;
+
+include_shipstern_parser!("../idls/padded_cpi_event_envelope.json");
+
+/// Envelope tag, three padding bytes, event discriminator.
+const ENVELOPE_AND_DISCRIMINATOR: [u8; 6] = [0xfe, 0x00, 0x00, 0x00, 0xa1, 0xa2];
+
+/// Event discriminator alone, as a `Program data:` log line carries it.
+const DISCRIMINATOR_ONLY: [u8; 2] = [0xa1, 0xa2];
+
+const AMOUNT: u64 = 7_654_321;
+
+fn program_id() -> Pubkey { Pubkey::new(padded_envelope::PROGRAM_ID) }
+
+/// Build a top-level instruction carrying one self-CPI event as an inner instruction.
+fn update_with_cpi_event(event_data: Vec<u8>) -> InstructionUpdate {
+    let shared = Arc::new(InstructionShared::default());
+
+    let inner = InstructionUpdate {
+        program: program_id(),
+        accounts: vec![],
+        data: event_data,
+        shared: Arc::clone(&shared),
+        inner: vec![],
+        path: Path::new_single(0),
+        log_range: 0..0,
+    };
+
+    InstructionUpdate {
+        program: program_id(),
+        accounts: vec![],
+        // The outer instruction is `doThing`, whose discriminator the IDL declares.
+        data: vec![1, 2, 3, 4, 5, 6, 7, 8],
+        shared,
+        inner: vec![inner],
+        path: Path::new_single(0),
+        log_range: 0..0,
+    }
+}
+
+///
+/// The CPI path must strip the IDL's `payload_offset` (4), not a fixed 8.
+///
+/// Stripping 8 would consume `fe 00 00 00 a1 a2` plus the first two borsh
+/// bytes, so no discriminator matches and no event is produced.
+///
+#[tokio::test]
+async fn cpi_path_strips_idl_payload_offset() {
+    let mut data = ENVELOPE_AND_DISCRIMINATOR.to_vec();
+    data.extend_from_slice(&AMOUNT.to_le_bytes());
+
+    let parser = padded_envelope::InstructionParser;
+    let output = parser
+        .parse(&update_with_cpi_event(data))
+        .await
+        .expect("padded CPI event should parse");
+
+    assert_eq!(
+        output.program_events.len(),
+        1,
+        "expected exactly one event from the inner self-CPI instruction",
+    );
+
+    let padded_envelope::event::Event::AlphaEvent { args, .. } = &output.program_events[0].event;
+
+    assert_eq!(args.amount, AMOUNT);
+}
+
+///
+/// The log path sees no envelope, so the same IDL offsets must still match.
+///
+/// `emit!` writes `[event discriminator][borsh payload]` with neither envelope
+/// nor padding, which is why the discriminators are rebased onto the
+/// envelope-stripped layout rather than handled per path.
+///
+#[test]
+fn log_path_matches_without_envelope() {
+    use base64::Engine;
+
+    let mut data = DISCRIMINATOR_ONLY.to_vec();
+    data.extend_from_slice(&AMOUNT.to_le_bytes());
+
+    let encoded = base64::engine::general_purpose::STANDARD.encode(&data);
+
+    let program = program_id().to_string();
+    let logs = vec![
+        format!("Program {program} invoke [1]"),
+        format!("Program data: {encoded}"),
+        format!("Program {program} success"),
+    ];
+
+    let events = padded_envelope::resolve_events_from_logs(&logs);
+
+    assert_eq!(events.len(), 1, "expected one event from the log line");
+
+    let padded_envelope::event::Event::AlphaEvent { args, .. } = &events[0].event;
+
+    assert_eq!(args.amount, AMOUNT);
+}

--- a/tests/proc-macro-events/tests/single_discriminator_event.rs
+++ b/tests/proc-macro-events/tests/single_discriminator_event.rs
@@ -1,0 +1,99 @@
+//!
+//! An event that declares no envelope must behave exactly as it did before the
+//! envelope work, on both paths.
+//!
+//! `epsilonEvent` has one discriminator, `e1e2`@0, so `envelope_of` returns
+//! `Ok(None)`, nothing is rebased, and the CPI path falls back to Anchor's
+//! default envelope. This is the precedence rule that keeps every pre-existing
+//! IDL working, and it was previously covered only implicitly by other test
+//! files continuing to pass.
+//!
+
+use std::sync::Arc;
+
+use shipstern_core::{
+    instruction::{InstructionShared, InstructionUpdate, Path},
+    Parser, Pubkey,
+};
+use shipstern_proc_macro::include_shipstern_parser;
+
+/// Anchor's `emit_cpi!` tag: `EVENT_IX_TAG.to_le_bytes()`.
+const ANCHOR_EVENT_IX_TAG: [u8; 8] = [0xe4, 0x45, 0xa5, 0x2e, 0x51, 0xcb, 0x9a, 0x1d];
+
+/// The event's own discriminator, which sits at offset 0 of the payload.
+const EVENT_DISCRIMINATOR: [u8; 2] = [0xe1, 0xe2];
+
+const AMOUNT: u64 = 1_234_567;
+
+include_shipstern_parser!("../idls/single_discriminator_event.json");
+
+fn program_id() -> Pubkey { Pubkey::new(plain_envelope::PROGRAM_ID) }
+
+///
+/// With no envelope in the IDL, the CPI path must still strip Anchor's tag.
+///
+#[tokio::test]
+async fn cpi_path_falls_back_to_the_anchor_envelope() {
+    let mut event_data = ANCHOR_EVENT_IX_TAG.to_vec();
+    event_data.extend_from_slice(&EVENT_DISCRIMINATOR);
+    event_data.extend_from_slice(&AMOUNT.to_le_bytes());
+
+    let shared = Arc::new(InstructionShared::default());
+
+    let inner = InstructionUpdate {
+        program: program_id(),
+        accounts: vec![],
+        data: event_data,
+        shared: Arc::clone(&shared),
+        inner: vec![],
+        path: Path::new_single(0),
+        log_range: 0..0,
+    };
+
+    let update = InstructionUpdate {
+        program: program_id(),
+        accounts: vec![],
+        data: vec![1, 2, 3, 4, 5, 6, 7, 8],
+        shared,
+        inner: vec![inner],
+        path: Path::new_single(0),
+        log_range: 0..0,
+    };
+
+    let parser = plain_envelope::InstructionParser;
+    let output = parser.parse(&update).await.expect("should parse");
+
+    assert_eq!(output.program_events.len(), 1);
+
+    let plain_envelope::event::Event::EpsilonEvent { args, .. } = &output.program_events[0].event;
+
+    assert_eq!(args.amount, AMOUNT);
+}
+
+///
+/// The log path matches the discriminator at offset 0, unchanged.
+///
+#[test]
+fn log_path_matches_at_offset_zero() {
+    use base64::Engine;
+
+    let mut data = EVENT_DISCRIMINATOR.to_vec();
+    data.extend_from_slice(&AMOUNT.to_le_bytes());
+
+    let encoded = base64::engine::general_purpose::STANDARD.encode(&data);
+
+    let program = program_id().to_string();
+    let logs = vec![
+        format!("Program {program} invoke [1]"),
+        format!("Program data: {encoded}"),
+        format!("Program {program} success"),
+    ];
+
+    let events = plain_envelope::resolve_events_from_logs(&logs);
+
+    assert_eq!(events.len(), 1);
+
+    let plain_envelope::event::Event::EpsilonEvent { args, .. } = &events[0].event;
+
+    assert_eq!(args.amount, AMOUNT);
+}


### PR DESCRIPTION
## Symptom

An IDL that declares the self-CPI event envelope on `eventNode.discriminators`,
which is the shape Carbon and `@codama/renderers-vixen-parser` produce, doesn't
build. Convert `tests/idls/perpetuals.json` to that form and you get:

    error: Event discriminator collision: [createPositionRequestEvent,
    instantCreateTpslEvent, ... withdrawFeesEvent] share the same discriminator.

All 25 events collapse onto one discriminator.

## Cause

Not a gap in Codama. The envelope is expressible today and `codama-nodes 0.9.1`
deserializes it fine. The parser just never reads past the first discriminator.

`extract_discriminator_key` and `extract_discriminator_info` both start with
`discriminators.first()?`. For `[const e445a52e51cb9a1d @0, const <event> @8]`
that returns the envelope tag, which is identical for every event in the
program.

`EVENT_PAYLOAD_OFFSET` had the mirror problem. It came from `ParserConfig`, set
only by the `cpi_event_discriminator` macro args from #272 and defaulting to 8,
so the CPI path always stripped a fixed count regardless of what the IDL said.

## Fix

The envelope now comes from the IDL. `parse::envelope_of` reads it off the
discriminator chain: constant at offset 0 is the tag, the rest is the event's
own discriminator, and `payload_offset` is `sorted[1].offset`. Codegen rebases
the remaining discriminators by that offset so the CPI and log paths see the
same layout, and ANDs a chain of two or more, reading the payload after the last
one.

`payload_offset` is the declared offset of the next discriminator, not the tag
length, so padded layouts work. Carbon requires contiguity and rejects them.

| IDL shape | before | after |
| --- | --- | --- |
| single discriminator (all current fixtures) | parses | unchanged |
| envelope, 8-byte Anchor tag | build fails | parses |
| envelope, short tag with padding | strips 8, lands inside the payload | strips 4, correct |
| 3+ discriminators with a gap | only the first checked | all checked |

Row 3 is the one that fails quietly. On an 8-byte tag `payload_offset` is 8 and
the old hardcoded 8 agrees by accident, so this only bites on short or padded
envelopes.

Ambiguous IDLs now fail the build instead of parsing to something arbitrary: two
constants at offset 0, overlapping ranges, a mix of constant and non-constant
nodes behind a tag, an event whose only discriminator is the tag, and bytes that
don't decode. That last one used to panic the macro through the shared decoder's
`expect`.

There's also a guard for an envelope tag that prefixes an instruction
discriminator at offset 0. The parser filters any instruction whose data starts
with the tag before dispatch, so that instruction could never parse. It checks
the tag the parser actually uses, so IDL envelopes, the macro-arg fallback and
the Anchor default are all covered. Instruction variants that share a
discriminator with each other are untouched.

Instruction parsing doesn't change. The chain logic is only in
`extract_event_discriminator_{key,info}` and the shared privates still read
`.first()`.

`cpi_event_discriminator` and `cpi_event_payload_offset` still work for IDLs
with no envelope. If the IDL declares one it wins and the call site gets a
deprecation warning. Both go away in 0.10.

## Alternatives

Putting the envelope on `programNode` as a `pluginNode` reads better, since it's
a program-level fact. It doesn't survive Codama. `plugins` is declared only on
`instructionNode`, and `identityVisitor` rebuilds nodes through generated
factories that drop undeclared keys, so it gets silently stripped.

A first-class envelope node in the spec is the right long-term answer, but
codama-idl/codama#77 is still open and labelled `v2`.

## Testing

    cargo test -p shipstern-proc-macro
    cargo test -p proc-macro-test
    cd tests/proc-macro-events && cargo test

Five fixtures cover the padded envelope, a 3+ chain with a gap, an account-count
collision group with a live envelope, an instruction with two constant
discriminators, and a single-discriminator IDL on the Anchor default. Each one
was checked to fail with the fix removed.

Also ran it against real `emit_cpi!` output from
`PERPHjGBqRHArX4DySjwM6UJHiR3sWAatqfdBS2qQJu`, from a mainnet fixture and a live
gRPC stream. That needs a credentialed endpoint so it isn't in CI.

`Vixen.toml` is gitignored here. It holds a local endpoint and token and was
never meant to be committed.

## Context

Follows #272, which added the macro args this replaces.
`docs/codama-parser-generation.md` has the IDL shape, the deprecation, and two
differences from Carbon: mixed `emit_cpi!` / `emit!` programs are accepted here
and rejected wholesale there, and an event with a genuine two-part discriminator
starting at offset 0 is read as enveloped, since nothing distinguishes the two.
