### PR TITLE
feat(core): expose Transaction V1 inline budget (SIMD-0385)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14536,9 +14536,9 @@ dependencies = [
 
 [[package]]
 name = "yellowstone-grpc-proto"
-version = "12.5.0"
+version = "12.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91071690a2b0a078a4712ecca7be37aa929b474a74f4f269c61582f8e2a6139"
+checksum = "bdceeb3f02e4b31ab481eb9fd714854d757e76d2eb7b4f9c00136ed19edf183f"
 dependencies = [
  "anyhow",
  "prost 0.14.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,7 +104,7 @@ warp = "0.3"
 yellowstone-block-machine = { version = "0.4.0" }
 yellowstone-fumarole-client = "0.4.0+solana.3"
 yellowstone-grpc-client = { version = ">=13.1, <13.3" }
-yellowstone-grpc-proto = { version = "12.4", default-features = false }
+yellowstone-grpc-proto = { version = "12.6", default-features = false }
 rdkafka = { version = "0.36", features = ["cmake-build", "ssl", "zstd"] }
 reqwest = { version = "0.12", features = ["json", "blocking", "stream"] }
 

--- a/crates/core/src/instruction.rs
+++ b/crates/core/src/instruction.rs
@@ -7,7 +7,7 @@ use yellowstone_grpc_proto::{
     prelude::MessageHeader,
     solana::storage::confirmed_block::{
         CompiledInstruction, InnerInstruction, InnerInstructions, Message, Reward, TokenBalance,
-        Transaction, TransactionError, TransactionStatusMeta,
+        Transaction, TransactionConfig, TransactionError, TransactionStatusMeta,
     },
 };
 
@@ -95,6 +95,8 @@ pub struct InstructionShared {
     pub accounts: AccountKeys,
     /// The header of the transaction.
     pub message_header: MessageHeader,
+    /// The inline transaction budget config introduced by Transaction V1
+    pub transaction_config: Option<TransactionConfig>,
 }
 
 /// A parsed instruction from a transaction update.
@@ -350,6 +352,7 @@ impl InstructionUpdate {
             instructions,
             versioned: _,
             address_table_lookups: _,
+            config,
         } = message.ok_or(Missing::TransactionMessage)?;
 
         let shared = Arc::new(InstructionShared {
@@ -373,6 +376,7 @@ impl InstructionUpdate {
                 dynamic_ro: loaded_readonly_addresses,
             },
             message_header: header.ok_or(Missing::TransactionMessageHeader)?,
+            transaction_config: config,
         });
 
         #[allow(clippy::cast_possible_truncation)] // instruction count never exceeds u32::MAX
@@ -687,7 +691,8 @@ mod tests {
 
     use super::{
         CompiledInstruction, InnerInstruction, InnerInstructions, InstructionShared,
-        InstructionUpdate, Message, MessageHeader, Transaction, TransactionStatusMeta,
+        InstructionUpdate, Message, MessageHeader, Transaction, TransactionConfig,
+        TransactionStatusMeta,
     };
     use crate::TransactionUpdate;
 
@@ -905,6 +910,7 @@ mod tests {
                         instructions: vec![compiled_instruction(0)],
                         versioned: false,
                         address_table_lookups: vec![],
+                        config: None,
                     }),
                 }),
                 meta: Some(TransactionStatusMeta {
@@ -957,6 +963,7 @@ mod tests {
                         instructions: vec![compiled_instruction(0)],
                         versioned: false,
                         address_table_lookups: vec![],
+                        config: None,
                     }),
                 }),
                 meta: Some(TransactionStatusMeta {
@@ -1036,6 +1043,7 @@ mod tests {
                         ],
                         versioned: false,
                         address_table_lookups: vec![],
+                        config: None,
                     }),
                 }),
                 meta: Some(TransactionStatusMeta {
@@ -1087,6 +1095,87 @@ mod tests {
             accounts: vec![],
             data: vec![],
             stack_height: Some(stack_height),
+        }
+    }
+
+    #[test]
+    fn v1_transaction_config_is_exposed_on_shared_tx_ctx() {
+        let txn = transaction_v1_with_inline_budget();
+
+        let instructions =
+            InstructionUpdate::build_from_txn(&txn).expect("v1 transaction should build");
+
+        assert_eq!(instructions.len(), 1);
+        let config = instructions[0]
+            .shared
+            .transaction_config
+            .as_ref()
+            .expect("v1 transaction_config should be populated");
+        assert_eq!(config.priority_fee, Some(5_000));
+        assert_eq!(config.compute_unit_limit, Some(200_000));
+        assert_eq!(config.loaded_accounts_data_size_limit, Some(65_536));
+        assert_eq!(config.heap_size, Some(262_144));
+    }
+
+    #[test]
+    fn legacy_transaction_has_no_inline_budget() {
+        let txn = transaction_with_missing_inner_stack_heights();
+
+        let instructions =
+            InstructionUpdate::build_from_txn(&txn).expect("transaction should build");
+
+        assert!(instructions[0].shared.transaction_config.is_none());
+    }
+
+    fn transaction_v1_with_inline_budget() -> TransactionUpdate {
+        TransactionUpdate {
+            slot: 1,
+            transaction: Some(SubscribeUpdateTransactionInfo {
+                signature: vec![9; 64],
+                is_vote: false,
+                transaction: Some(Transaction {
+                    signatures: vec![vec![9; 64]],
+                    message: Some(Message {
+                        header: Some(MessageHeader {
+                            num_required_signatures: 1,
+                            num_readonly_signed_accounts: 0,
+                            num_readonly_unsigned_accounts: 0,
+                        }),
+                        // V1 inlines every address, so there are no ATL entries.
+                        account_keys: (0..8).map(|byte| vec![byte; 32]).collect(),
+                        recent_blockhash: vec![7; 32],
+                        instructions: vec![compiled_instruction(0)],
+                        versioned: true,
+                        address_table_lookups: vec![],
+                        config: Some(TransactionConfig {
+                            priority_fee: Some(5_000),
+                            compute_unit_limit: Some(200_000),
+                            loaded_accounts_data_size_limit: Some(65_536),
+                            heap_size: Some(262_144),
+                        }),
+                    }),
+                }),
+                meta: Some(TransactionStatusMeta {
+                    err: None,
+                    fee: 0,
+                    pre_balances: vec![],
+                    post_balances: vec![],
+                    inner_instructions: vec![],
+                    inner_instructions_none: false,
+                    log_messages: vec![],
+                    log_messages_none: false,
+                    pre_token_balances: vec![],
+                    post_token_balances: vec![],
+                    rewards: vec![],
+                    loaded_writable_addresses: vec![],
+                    loaded_readonly_addresses: vec![],
+                    return_data: None,
+                    return_data_none: true,
+                    compute_units_consumed: None,
+                    cost_units: None,
+                }),
+                index: 0,
+            }),
         }
     }
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -981,6 +981,9 @@ impl From<Filters> for SubscribeRequest {
                     Some((k.clone(), SubscribeRequestFilterTransactions {
                         vote: None,
                         failed: v.failed,
+                        // Cuckoo-filter account matching (proto 12.6.0) is not
+                        // exposed through `TransactionFilter`; opt out for now.
+                        cuckoo_account_include: None,
                         signature: None,
                         account_include: v
                             .accounts_include

--- a/crates/jetstreamer-source/src/lib.rs
+++ b/crates/jetstreamer-source/src/lib.rs
@@ -1560,6 +1560,9 @@ mod convert {
                     .collect(),
                 versioned,
                 address_table_lookups,
+                // Firehose transactions are decoded from the Agave-3 SDK, which
+                // has no V1 message variant, so there is never an inline budget.
+                config: None,
             }
         };
 

--- a/crates/runtime/src/instruction.rs
+++ b/crates/runtime/src/instruction.rs
@@ -272,6 +272,7 @@ mod tests {
                         instructions,
                         versioned: false,
                         address_table_lookups: vec![],
+                        config: None,
                     }),
                 }),
                 meta: Some(TransactionStatusMeta {


### PR DESCRIPTION
## Summary

Adds support for Agave Transaction V1. V1 (SIMD-0385) moves the
compute budget out of top-level `ComputeBudget` instructions into an inline
`TransactionConfig` on the message — carried on the wire as `Message.config`
(field 7, added in `yellowstone-grpc-proto` 12.6.0). shipstern destructured the
message without that field, so it was dropped and V1 messages fail to build once
proto reaches 12.6.0.

## Approach

- Bump `yellowstone-grpc-proto` to `12.6`.
- Add `InstructionShared::transaction_config: Option<TransactionConfig>`,
  populated from `Message.config` (`None` for Legacy/V0). Parsers read a V1
  transaction's priority fee / CU limit / loaded-accounts data-size / heap from
  `ix.shared.transaction_config`.
- Handle the new `SubscribeRequestFilterTransactions::cuckoo_account_include`
  (opt-out; cuckoo filtering isn't exposed through `TransactionFilter`).
- Update the firehose (jetstreamer) SDK→proto conversion + test fixtures.
- Add round-trip tests for V1 budget exposure and the Legacy/V0 `None` case.

## Testing

`cargo check --workspace --all-targets`, `cargo clippy --all-targets --tests
-Dwarnings`, `cargo test --workspace --lib --tests` (286 passed), `cargo fmt --check`.
