### PR TITLE
Edit, validate and reset filters through a sync RuntimeHandle

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -17,7 +17,7 @@
 
 use std::{
     borrow::Cow,
-    collections::{HashMap, HashSet},
+    collections::{hash_map::Entry, HashMap, HashSet},
     fmt::{self, Debug},
     future::Future,
     str::FromStr,
@@ -916,6 +916,55 @@ impl Filters {
             parsers_filters: filters,
         }
     }
+
+    /// The prefilter registered under `parser_id`, if any.
+    #[inline]
+    #[must_use]
+    pub fn get(&self, parser_id: &str) -> Option<&Prefilter> { self.parsers_filters.get(parser_id) }
+
+    /// Parser IDs this set subscribes for.
+    #[inline]
+    pub fn parser_ids(&self) -> impl Iterator<Item = &str> {
+        self.parsers_filters.keys().map(String::as_str)
+    }
+
+    /// Replace the prefilter under `parser_id`, returning the previous one.
+    ///
+    /// ```rust, ignore
+    /// let narrower = Prefilter::builder().account_owners([mint]).build()?;
+    /// filters.insert(parser.id(), narrower);
+    /// ```
+    #[inline]
+    pub fn insert(
+        &mut self,
+        parser_id: impl Into<String>,
+        prefilter: Prefilter,
+    ) -> Option<Prefilter> {
+        self.parsers_filters.insert(parser_id.into(), prefilter)
+    }
+
+    /// Union `prefilter` into the one under `parser_id`, inserting it when
+    /// there is none yet.
+    ///
+    /// ```rust, ignore
+    /// let extra = Prefilter::builder().account_owners([new_mint]).build()?;
+    /// filters.merge(parser.id(), extra);
+    /// ```
+    pub fn merge(&mut self, parser_id: impl Into<String>, prefilter: Prefilter) {
+        match self.parsers_filters.entry(parser_id.into()) {
+            Entry::Occupied(mut existing) => existing.get_mut().merge(prefilter),
+            Entry::Vacant(slot) => {
+                slot.insert(prefilter);
+            },
+        }
+    }
+
+    /// Drop the prefilter under `parser_id`, so the set no longer subscribes
+    /// for that parser. Returns the removed prefilter.
+    #[inline]
+    pub fn remove(&mut self, parser_id: &str) -> Option<Prefilter> {
+        self.parsers_filters.remove(parser_id)
+    }
 }
 
 /// Type mirroring the `CommitmentLevel` enum in the `geyser` crate but serializable.
@@ -1037,6 +1086,77 @@ impl From<Filters> for SubscribeRequest {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn owned_by(marker: u8) -> Prefilter {
+        Prefilter {
+            account: Some(AccountPrefilter {
+                accounts: HashSet::new(),
+                owners: HashSet::from([Pubkey::new([marker; 32])]),
+            }),
+            ..Default::default()
+        }
+    }
+
+    fn owners_of(filters: &Filters, parser_id: &str) -> HashSet<Pubkey> {
+        filters
+            .get(parser_id)
+            .and_then(|prefilter| prefilter.account.as_ref())
+            .map(|account| account.owners.clone())
+            .unwrap_or_default()
+    }
+
+    #[test]
+    fn test_filters_merge_unions_into_an_existing_prefilter() {
+        let mut filters = Filters::new(HashMap::from([("p".to_owned(), owned_by(1))]));
+
+        filters.merge("p", owned_by(2));
+
+        assert_eq!(
+            owners_of(&filters, "p"),
+            HashSet::from([Pubkey::new([1; 32]), Pubkey::new([2; 32])])
+        );
+    }
+
+    #[test]
+    fn test_filters_merge_inserts_when_absent() {
+        let mut filters = Filters::new(HashMap::new());
+
+        filters.merge("p", owned_by(1));
+
+        assert_eq!(
+            owners_of(&filters, "p"),
+            HashSet::from([Pubkey::new([1; 32])])
+        );
+    }
+
+    #[test]
+    fn test_filters_insert_replaces_and_returns_the_previous_prefilter() {
+        let mut filters = Filters::new(HashMap::from([("p".to_owned(), owned_by(1))]));
+
+        let previous = filters.insert("p", owned_by(2));
+
+        assert_eq!(
+            previous
+                .and_then(|prefilter| prefilter.account)
+                .map(|a| a.owners),
+            Some(HashSet::from([Pubkey::new([1; 32])]))
+        );
+        assert_eq!(
+            owners_of(&filters, "p"),
+            HashSet::from([Pubkey::new([2; 32])])
+        );
+    }
+
+    #[test]
+    fn test_filters_remove_drops_the_parser() {
+        let mut filters = Filters::new(HashMap::from([("p".to_owned(), owned_by(1))]));
+
+        assert!(filters.remove("p").is_some());
+        assert!(filters.get("p").is_none());
+        assert_eq!(filters.parser_ids().count(), 0);
+        assert!(filters.remove("p").is_none());
+    }
+
     fn block_prefilter(
         include_accounts: bool,
         include_transactions: bool,

--- a/crates/runtime/src/builder.rs
+++ b/crates/runtime/src/builder.rs
@@ -1,23 +1,20 @@
 //! Builder types for the Shipstern runtime and stream server.
+use std::sync::Arc;
+
 use shipstern_core::{
     instruction::InstructionUpdate, AccountUpdate, BlockMetaUpdate, BlockUpdate, SlotUpdate,
     TransactionUpdate,
 };
-use tokio::sync::mpsc;
+use tokio::sync::watch;
 
 use crate::{
     config::ShipsternConfig,
+    handle::FilterState,
     handler::{BoxPipeline, DynPipeline, PipelineSet, PipelineSets},
     instruction::InstructionPipeline,
     sources::SourceTrait,
     util, Runtime,
 };
-
-/// Depth of the filter update channel behind
-/// [`RuntimeHandle::send_filter_update`](crate::RuntimeHandle::send_filter_update).
-/// Updates are rare, so a shallow queue is enough to keep a caller from
-/// blocking on a short burst.
-const FILTER_UPDATE_CHANNEL_SIZE: usize = 8;
 
 /// Helper trait for defining the intended use for a builder.
 pub trait BuilderKind: Default {
@@ -272,14 +269,15 @@ impl<S: SourceTrait> RuntimeBuilder<S> {
             return Err(BuilderError::SlotPipelineCollision);
         }
 
-        let (filter_updates_tx, filter_updates_rx) = mpsc::channel(FILTER_UPDATE_CHANNEL_SIZE);
+        let (filter_updates_tx, filter_updates_rx) = watch::channel(pipelines.filters());
+        let filter_state = Arc::new(FilterState::new(filter_updates_tx));
 
         Ok(Runtime {
             buffer: buffer_cfg,
             source: source_cfg,
             pipelines,
-            filter_updates_tx,
             filter_updates_rx,
+            filter_state,
             _source: std::marker::PhantomData,
             #[cfg(feature = "prometheus")]
             metrics_registry,

--- a/crates/runtime/src/handle.rs
+++ b/crates/runtime/src/handle.rs
@@ -1,10 +1,12 @@
 //! A handle for talking to a [`Runtime`](crate::Runtime) after it has started.
 
+use std::sync::{Arc, Mutex, PoisonError};
+
 use shipstern_core::Filters;
-use tokio::sync::mpsc;
+use tokio::sync::watch;
 
 /// Why a filter update never reached the source.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum FilterUpdateError {
     /// The source behind the runtime cannot change its subscription
     /// mid-stream, so no update could ever take effect.
@@ -14,123 +16,195 @@ pub enum FilterUpdateError {
     /// is left to apply the set.
     #[error("the runtime is no longer running")]
     Closed,
+    /// The set names a parser no pipeline on this runtime is registered for.
+    /// The server would stream that data and the runtime would discard all of
+    /// it, so the update is refused before anything is sent.
+    #[error("no pipeline registered for parser `{0}`")]
+    UnknownParser(String),
 }
 
-/// A handle onto a [`Runtime`](crate::Runtime) that outlives the runtime
-/// value itself.
+/// Filter state shared by every handle onto one runtime.
+///
+/// The `watch` slot is both the transport to the source and the record of the
+/// last set handed off, so the two can never disagree.
+#[derive(Debug)]
+pub(crate) struct FilterState {
+    /// The set the pipelines were built with. Also the source of truth for
+    /// which parser IDs an update may name.
+    initial: Filters,
+    /// Latest set for the source. A newer set replaces one the source has not
+    /// read yet, which is what the servers do with successive requests anyway.
+    filter_updates_tx: watch::Sender<Filters>,
+    /// Serialises read-modify-write sequences across handles, so two
+    /// concurrent edits cannot interleave and lose one another. Never held
+    /// across an await.
+    update_lock: Mutex<()>,
+}
+
+impl FilterState {
+    pub(crate) fn new(filter_updates_tx: watch::Sender<Filters>) -> Self {
+        let initial = filter_updates_tx.borrow().clone();
+
+        Self {
+            initial,
+            filter_updates_tx,
+            update_lock: Mutex::new(()),
+        }
+    }
+
+    /// The set the pipelines were built with.
+    pub(crate) fn initial(&self) -> &Filters { &self.initial }
+
+    fn snapshot(&self) -> Filters { self.filter_updates_tx.borrow().clone() }
+
+    /// Refuse a set naming a parser that has no registered pipeline.
+    fn validate(&self, filters: &Filters) -> Result<(), FilterUpdateError> {
+        let unknown = filters
+            .parser_ids()
+            .find(|id| !self.initial.parsers_filters.contains_key(*id));
+
+        match unknown {
+            Some(id) => Err(FilterUpdateError::UnknownParser(id.to_owned())),
+            None => Ok(()),
+        }
+    }
+}
+
+/// A handle onto a [`Runtime`](crate::Runtime) for changing its subscription
+/// while it runs.
 ///
 /// [`Runtime::run`](crate::Runtime::run) and its variants take the runtime by
-/// value, so take a handle with [`Runtime::handle`](crate::Runtime::handle)
-/// first and use that from wherever the update originates. Handles are cheap
-/// to clone and every clone addresses the same runtime.
-///
-/// # Example
+/// value, so take the handle with [`Runtime::handle`](crate::Runtime::handle)
+/// first. Handles are cheap to clone, share one view of the filters, and work
+/// from async and plain threads alike since nothing here awaits.
 ///
 /// ```rust, ignore
 /// let runtime = Runtime::<YellowstoneGrpcSource>::builder()
-///     .instruction(Pipeline::new(TokenProgramIxParser, [Handler]))
+///     .account(Pipeline::new(TokenProgramAccParser, [Handler]))
 ///     .try_build(config)?;
 ///
 /// let handle = runtime.handle();
 /// tokio::spawn(runtime.run_async());
 ///
-/// handle.send_filter_update(new_filters).await?;
+/// // Widen the account subscription with one more owner.
+/// let extra = Prefilter::builder().account_owners([new_mint]).build()?;
+/// handle.update_filters(|filters| filters.merge(TokenProgramAccParser.id(), extra))?;
+///
+/// // Back to what the pipelines were built with.
+/// handle.reset_filters()?;
 /// ```
+///
+/// # Semantics
+///
+/// - Every update sends the complete set and replaces the live subscription,
+///   which is what gRPC servers do with a mid-stream request.
+/// - Keys are parser IDs, and only IDs with a registered pipeline are
+///   accepted. Take them from [`Parser::id`](shipstern_core::Parser::id).
+/// - `Ok(())` means the set was handed to the source, not that the server
+///   applied it. Handlers keep seeing updates matching the old set until the
+///   already-queued backlog drains, roughly however far behind the pipeline
+///   was at the time.
+/// - Only the newest set matters. Two updates in quick succession may reach
+///   the source as the second alone, and a set rejected while the source is
+///   between connections is retried once the stream recovers.
+/// - A set the server refuses, by exceeding its filter limits for example,
+///   ends the run. Under `run` and `run_async` that exits the process.
 #[derive(Debug, Clone)]
 pub struct RuntimeHandle {
-    /// `None` when the source behind the runtime ignores filter updates, so a
-    /// send fails at the call site instead of vanishing into a channel nobody
+    /// Whether the source behind the runtime applies filter updates, so a
+    /// send fails at the call site instead of vanishing into a slot nobody
     /// reads.
-    filter_updates_tx: Option<mpsc::Sender<Filters>>,
+    supported: bool,
+    state: Arc<FilterState>,
 }
 
 impl RuntimeHandle {
-    pub(crate) fn new(filter_updates_tx: Option<mpsc::Sender<Filters>>) -> Self {
-        Self { filter_updates_tx }
+    pub(crate) fn new(supported: bool, state: Arc<FilterState>) -> Self {
+        Self { supported, state }
     }
 
-    /// Replace the live subscription with `filters`.
+    /// The last filter set handed to the source, seeded from the registered
+    /// pipelines.
     ///
-    /// Each [`Filters`] sent replaces the whole subscription rather than
-    /// adding to it, because that is what the gRPC servers do with a
-    /// mid-stream request, so send the complete set every time.
+    /// ```rust, ignore
+    /// let owners = handle
+    ///     .filters()
+    ///     .get(&TokenProgramAccParser.id())
+    ///     .and_then(|prefilter| prefilter.account.as_ref())
+    ///     .map(|account| account.owners.clone());
+    /// ```
+    #[must_use]
+    pub fn filters(&self) -> Filters { self.state.snapshot() }
+
+    /// Edit the live filter set in place and send the result.
     ///
-    /// Keys are parser IDs. A key matching no registered pipeline still
-    /// changes the wire subscription, so the server streams that data and the
-    /// runtime then drops every update of it with only a trace-level line, so
-    /// take the keys from the parsers actually registered on this runtime.
+    /// `edit` sees a copy of the current set, and the result replaces the
+    /// subscription. Concurrent calls from any handle are applied one after
+    /// another, so no edit is lost.
     ///
-    /// The server applies the new set promptly, but a consumer sees it only
-    /// once whatever it has already queued drains, so the delay is however far
-    /// behind the pipeline already was rather than a property of the update.
-    /// Measured against a live endpoint, a consumer running about 15 seconds
-    /// behind kept receiving the old set for roughly that long after the send,
-    /// and the first updates matching the new set arrived stale by the same
-    /// margin before catching up to real time. A pipeline keeping pace sees
-    /// the change almost at once.
-    ///
-    /// Treat `Ok(())` as the request having been handed off, not as the
-    /// subscription having changed, and keep handlers able to cope with
-    /// updates matching the old set until the backlog clears.
-    ///
-    /// Delivery is best effort. A set rejected while the source is between
-    /// connections is retried once the stream recovers, but nothing reports
-    /// back to the sender either way, and a newer set arriving in the meantime
-    /// replaces the held one rather than queueing behind it. Every set is
-    /// complete rather than a delta, so the server still ends on the newest,
-    /// but an intermediate set can be skipped.
-    ///
-    /// A set the server itself refuses, by exceeding its configured filter
-    /// limits for example, is answered on the stream with a code the client
-    /// does not treat as recoverable, and the run ends with that error rather
-    /// than the previous subscription staying in place. Under
-    /// [`Runtime::run`](crate::Runtime::run) and
-    /// [`Runtime::run_async`](crate::Runtime::run_async) that error is fatal
-    /// and exits the process, so a set the provider will not accept takes the
-    /// whole indexer down. Use
-    /// [`Runtime::try_run_async`](crate::Runtime::try_run_async) if a caller
-    /// needs to survive one.
-    ///
-    /// A set sent before the runtime starts is queued and applied as soon as
-    /// the source connects. A short burst is buffered, and a sender that gets
-    /// far ahead of the source waits here until it catches up.
+    /// ```rust, ignore
+    /// handle.update_filters(|filters| {
+    ///     filters.merge(TokenProgramAccParser.id(), extra_owner);
+    ///     filters.remove(&TokenProgramIxParser.id());
+    /// })?;
+    /// ```
     ///
     /// # Errors
     ///
-    /// [`FilterUpdateError::Unsupported`] when the source cannot change its
-    /// subscription mid-stream, and [`FilterUpdateError::Closed`] once the
-    /// runtime has stopped.
+    /// [`FilterUpdateError::UnknownParser`] leaves the set untouched, and
+    /// nothing is sent. See [`FilterUpdateError`] for the rest.
     ///
-    pub async fn send_filter_update(&self, filters: Filters) -> Result<(), FilterUpdateError> {
-        let Some(tx) = &self.filter_updates_tx else {
+    pub fn update_filters<F>(&self, edit: F) -> Result<(), FilterUpdateError>
+    where F: FnOnce(&mut Filters) {
+        if !self.supported {
             return Err(FilterUpdateError::Unsupported);
-        };
+        }
 
-        tx.send(filters)
-            .await
+        let _serialised = self
+            .state
+            .update_lock
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner);
+
+        let mut next = self.state.snapshot();
+        edit(&mut next);
+        self.state.validate(&next)?;
+
+        // A failed send leaves the slot untouched, so `filters()` never
+        // reports a set that went nowhere.
+        self.state
+            .filter_updates_tx
+            .send(next)
             .map_err(|_| FilterUpdateError::Closed)
     }
 
-    /// Blocking variant of [`Self::send_filter_update`], for a thread without
-    /// a Tokio runtime of its own, such as one sitting next to a
-    /// [`Runtime::run`](crate::Runtime::run) call.
+    /// Replace the whole subscription with `filters`.
+    ///
+    /// ```rust, ignore
+    /// let mut filters = handle.filters();
+    /// filters.insert(TokenProgramAccParser.id(), narrower);
+    /// handle.send_filter_update(filters)?;
+    /// ```
     ///
     /// # Errors
     ///
-    /// The same as [`Self::send_filter_update`].
+    /// See [`FilterUpdateError`].
     ///
-    /// # Panics
-    ///
-    /// Panics when called from inside an asynchronous context, because
-    /// blocking there would stall the executor. Use
-    /// [`Self::send_filter_update`] from async code.
-    ///
-    pub fn blocking_send_filter_update(&self, filters: Filters) -> Result<(), FilterUpdateError> {
-        let Some(tx) = &self.filter_updates_tx else {
-            return Err(FilterUpdateError::Unsupported);
-        };
+    pub fn send_filter_update(&self, filters: Filters) -> Result<(), FilterUpdateError> {
+        self.update_filters(|current| *current = filters)
+    }
 
-        tx.blocking_send(filters)
-            .map_err(|_| FilterUpdateError::Closed)
+    /// Restore the set the pipelines were built with.
+    ///
+    /// ```rust, ignore
+    /// handle.reset_filters()?;
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// See [`FilterUpdateError`].
+    ///
+    pub fn reset_filters(&self) -> Result<(), FilterUpdateError> {
+        self.send_filter_update(self.state.initial.clone())
     }
 }

--- a/crates/runtime/src/handle.rs
+++ b/crates/runtime/src/handle.rs
@@ -8,10 +8,6 @@ use tokio::sync::watch;
 /// Why a filter update never reached the source.
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum FilterUpdateError {
-    /// The source behind the runtime cannot change its subscription
-    /// mid-stream, so no update could ever take effect.
-    #[error("the source does not support filter updates")]
-    Unsupported,
     /// The runtime has stopped, or was dropped without being run, so nothing
     /// is left to apply the set.
     #[error("the runtime is no longer running")]
@@ -75,8 +71,10 @@ impl FilterState {
 ///
 /// [`Runtime::run`](crate::Runtime::run) and its variants take the runtime by
 /// value, so take the handle with [`Runtime::handle`](crate::Runtime::handle)
-/// first. Handles are cheap to clone, share one view of the filters, and work
-/// from async and plain threads alike since nothing here awaits.
+/// first. It exists only for sources implementing
+/// [`FilterUpdateSource`](crate::sources::FilterUpdateSource). Handles are
+/// cheap to clone, share one view of the filters, and work from async and
+/// plain threads alike since nothing here awaits.
 ///
 /// ```rust, ignore
 /// let runtime = Runtime::<YellowstoneGrpcSource>::builder()
@@ -111,17 +109,11 @@ impl FilterState {
 ///   ends the run. Under `run` and `run_async` that exits the process.
 #[derive(Debug, Clone)]
 pub struct RuntimeHandle {
-    /// Whether the source behind the runtime applies filter updates, so a
-    /// send fails at the call site instead of vanishing into a slot nobody
-    /// reads.
-    supported: bool,
     state: Arc<FilterState>,
 }
 
 impl RuntimeHandle {
-    pub(crate) fn new(supported: bool, state: Arc<FilterState>) -> Self {
-        Self { supported, state }
-    }
+    pub(crate) fn new(state: Arc<FilterState>) -> Self { Self { state } }
 
     /// The last filter set handed to the source, seeded from the registered
     /// pipelines.
@@ -156,10 +148,6 @@ impl RuntimeHandle {
     ///
     pub fn update_filters<F>(&self, edit: F) -> Result<(), FilterUpdateError>
     where F: FnOnce(&mut Filters) {
-        if !self.supported {
-            return Err(FilterUpdateError::Unsupported);
-        }
-
         let _serialised = self
             .state
             .update_lock

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -12,11 +12,11 @@
 //! Shipstern provides a simple API for requesting, parsing, and consuming data
 //! from Yellowstone.
 
-use std::marker::PhantomData;
+use std::{marker::PhantomData, sync::Arc};
 
 use config::BufferConfig;
 use shipstern_core::Filters;
-use tokio::sync::{mpsc, oneshot};
+use tokio::sync::{mpsc, oneshot, watch};
 use yellowstone_grpc_proto::tonic::Status;
 
 use crate::sources::SourceExitStatus;
@@ -86,8 +86,8 @@ pub struct Runtime<S: SourceTrait> {
     buffer: BufferConfig,
     source: S::Config,
     pipelines: handler::PipelineSets,
-    filter_updates_tx: mpsc::Sender<Filters>,
-    filter_updates_rx: mpsc::Receiver<Filters>,
+    filter_updates_rx: watch::Receiver<Filters>,
+    filter_state: Arc<handle::FilterState>,
     #[cfg(feature = "prometheus")]
     metrics_registry: prometheus::Registry,
     _source: PhantomData<S>,
@@ -97,33 +97,28 @@ impl<S: SourceTrait> Runtime<S> {
     /// Create a new runtime builder.
     pub fn builder() -> RuntimeBuilder<S> { RuntimeBuilder::<S>::default() }
 
-    /// Create a handle for talking to this runtime once it is running.
+    /// Create a handle for changing this runtime's subscription once it is
+    /// running.
     ///
     /// [`Self::run`], [`Self::try_run`], [`Self::run_async`] and
     /// [`Self::try_run_async`] all consume the runtime, so take the handle
-    /// first. Handles are cheap to clone, and one taken from a source that
-    /// does not support filter updates still exists, but every
-    /// [`RuntimeHandle::send_filter_update`] on it fails with
+    /// first. Every handle shares one view of the filters, and one taken from
+    /// a source that cannot change its subscription fails each update with
     /// [`FilterUpdateError::Unsupported`].
-    ///
-    /// # Example
     ///
     /// ```rust, ignore
     /// let runtime = Runtime::<YellowstoneGrpcSource>::builder()
-    ///     .instruction(Pipeline::new(TokenProgramIxParser, [Handler]))
+    ///     .account(Pipeline::new(TokenProgramAccParser, [Handler]))
     ///     .try_build(config)?;
     ///
     /// let handle = runtime.handle();
     /// tokio::spawn(runtime.run_async());
     ///
-    /// handle.send_filter_update(new_filters).await?;
+    /// handle.update_filters(|filters| filters.merge(TokenProgramAccParser.id(), extra_owner))?;
     /// ```
     #[must_use]
     pub fn handle(&self) -> RuntimeHandle {
-        let filter_updates_tx =
-            S::supports_filter_updates().then(|| self.filter_updates_tx.clone());
-
-        RuntimeHandle::new(filter_updates_tx)
+        RuntimeHandle::new(S::supports_filter_updates(), Arc::clone(&self.filter_state))
     }
 }
 impl<S: SourceTrait> Runtime<S> {
@@ -283,15 +278,15 @@ impl<S: SourceTrait> Runtime<S> {
         #[cfg(feature = "prometheus")]
         metrics::register_metrics(&self.metrics_registry);
 
-        let filters = self.pipelines.filters();
+        let filters = self.filter_state.initial().clone();
 
         let source = S::new(self.source, filters);
         let filter_updates_rx = self.filter_updates_rx;
 
-        // Release the runtime's own sender so the channel closes once every
+        // Release the runtime's own reference so the slot closes once every
         // handle is gone, and a source that waits on updates is not left
         // waiting on a sender that can never produce one.
-        drop(self.filter_updates_tx);
+        drop(self.filter_state);
 
         tokio::spawn(async move {
             let _ = source

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -49,7 +49,10 @@ pub use shipstern_core::CommitmentLevel;
 pub use util::*;
 use yellowstone_grpc_proto::geyser::SubscribeUpdate;
 
-use crate::{builder::RuntimeBuilder, sources::SourceTrait};
+use crate::{
+    builder::RuntimeBuilder,
+    sources::{FilterUpdateSource, SourceTrait},
+};
 
 /// An error thrown by the Shipstern runtime.
 #[derive(Debug, thiserror::Error)]
@@ -96,15 +99,17 @@ pub struct Runtime<S: SourceTrait> {
 impl<S: SourceTrait> Runtime<S> {
     /// Create a new runtime builder.
     pub fn builder() -> RuntimeBuilder<S> { RuntimeBuilder::<S>::default() }
+}
 
+impl<S: FilterUpdateSource> Runtime<S> {
     /// Create a handle for changing this runtime's subscription once it is
     /// running.
     ///
-    /// [`Self::run`], [`Self::try_run`], [`Self::run_async`] and
+    /// Only available when the source implements [`FilterUpdateSource`], so a
+    /// runtime whose source cannot change its subscription has no handle to
+    /// take. [`Self::run`], [`Self::try_run`], [`Self::run_async`] and
     /// [`Self::try_run_async`] all consume the runtime, so take the handle
-    /// first. Every handle shares one view of the filters, and one taken from
-    /// a source that cannot change its subscription fails each update with
-    /// [`FilterUpdateError::Unsupported`].
+    /// first. Every handle shares one view of the filters.
     ///
     /// ```rust, ignore
     /// let runtime = Runtime::<YellowstoneGrpcSource>::builder()
@@ -117,9 +122,7 @@ impl<S: SourceTrait> Runtime<S> {
     /// handle.update_filters(|filters| filters.merge(TokenProgramAccParser.id(), extra_owner))?;
     /// ```
     #[must_use]
-    pub fn handle(&self) -> RuntimeHandle {
-        RuntimeHandle::new(S::supports_filter_updates(), Arc::clone(&self.filter_state))
-    }
+    pub fn handle(&self) -> RuntimeHandle { RuntimeHandle::new(Arc::clone(&self.filter_state)) }
 }
 impl<S: SourceTrait> Runtime<S> {
     /// Create a new Tokio runtime and run the Shipstern runtime within it,

--- a/crates/runtime/src/runtime_tests.rs
+++ b/crates/runtime/src/runtime_tests.rs
@@ -20,7 +20,7 @@ use yellowstone_grpc_proto::{
 
 use crate::{
     config::{BufferConfig, NullConfig, ShipsternConfig},
-    sources::{SourceExitStatus, SourceTrait},
+    sources::{FilterUpdateSource, SourceExitStatus, SourceTrait},
     Error, FilterUpdateError, Handler, Pipeline, Runtime,
 };
 
@@ -393,8 +393,6 @@ impl SourceTrait for MockFilterUpdateSource {
 
     fn new(_: NullConfig, _: Filters) -> Self { Self }
 
-    fn supports_filter_updates() -> bool { true }
-
     async fn connect(
         &self,
         tx: Sender<Result<SubscribeUpdate, tonic::Status>>,
@@ -429,6 +427,8 @@ impl SourceTrait for MockFilterUpdateSource {
         Ok(())
     }
 }
+
+impl FilterUpdateSource for MockFilterUpdateSource {}
 
 /// A runtime with one registered slot pipeline, so `TEST_SLOT_FILTER` is a
 /// parser ID that filter updates may name.
@@ -555,17 +555,6 @@ async fn test_reset_filters_restores_the_registered_set() {
     let filters = handle.filters();
     assert_eq!(filters.parser_ids().collect::<Vec<_>>(), [TEST_SLOT_FILTER]);
     assert!(owners_of(&filters, TEST_SLOT_FILTER).is_none());
-}
-
-#[tokio::test]
-async fn test_filter_updates_rejected_when_source_does_not_support_them() {
-    let runtime = Runtime::<MockStreamEndSource>::builder()
-        .try_build(default_test_config())
-        .unwrap();
-
-    let result = runtime.handle().reset_filters();
-
-    assert_eq!(result, Err(FilterUpdateError::Unsupported));
 }
 
 #[tokio::test]

--- a/crates/runtime/src/runtime_tests.rs
+++ b/crates/runtime/src/runtime_tests.rs
@@ -12,10 +12,7 @@ use async_trait::async_trait;
 use shipstern_core::{
     AccountPrefilter, Filters, ParseResult, Parser, Prefilter, Pubkey, SlotUpdate,
 };
-use tokio::sync::{
-    mpsc::{Receiver, Sender},
-    oneshot,
-};
+use tokio::sync::{mpsc::Sender, oneshot, watch};
 use yellowstone_grpc_proto::{
     geyser::{subscribe_update::UpdateOneof, SlotStatus, SubscribeUpdate, SubscribeUpdateSlot},
     tonic,
@@ -382,13 +379,10 @@ impl Handler<SlotUpdate, SlotUpdate> for SlowSlotHandler {
     }
 }
 
-/// Parser IDs carried by the filter sets a source received through the
-/// runtime filter update channel. Tests run in parallel and all share this,
-/// so each one records under its own ID and asserts on that ID alone.
-static RECEIVED_FILTER_IDS: Mutex<Vec<String>> = Mutex::new(Vec::new());
-
-/// Parser ID used only by [`test_filter_updates_reach_a_supporting_source`].
-const SWAPPED_PARSER_ID: &str = "test::SwappedParser";
+/// Filter sets a source received through the runtime filter update channel.
+/// Tests run in parallel and all share this, so each one marks its sets with
+/// its own owner pubkey and asserts on that marker alone.
+static RECEIVED_FILTERS: Mutex<Vec<Filters>> = Mutex::new(Vec::new());
 
 #[derive(Debug)]
 struct MockFilterUpdateSource;
@@ -413,19 +407,20 @@ impl SourceTrait for MockFilterUpdateSource {
         Ok(())
     }
 
+    /// Records every set until the last handle is dropped, then ends the
+    /// stream, so a test controls when the run finishes by dropping its
+    /// handle.
     async fn connect_with_filter_updates(
         &self,
         tx: Sender<Result<SubscribeUpdate, tonic::Status>>,
         status_tx: oneshot::Sender<SourceExitStatus>,
-        mut filter_updates_rx: Receiver<Filters>,
+        mut filter_updates_rx: watch::Receiver<Filters>,
     ) -> Result<(), Error> {
         wait_for_runtime_ready().await;
 
-        if let Some(filters) = filter_updates_rx.recv().await {
-            let mut ids = filters.parsers_filters.keys().cloned().collect::<Vec<_>>();
-            ids.sort();
-
-            RECEIVED_FILTER_IDS.lock().unwrap().extend(ids);
+        while filter_updates_rx.changed().await.is_ok() {
+            let filters = filter_updates_rx.borrow_and_update().clone();
+            RECEIVED_FILTERS.lock().unwrap().push(filters);
         }
 
         signal_stream_ended(status_tx);
@@ -435,50 +430,131 @@ impl SourceTrait for MockFilterUpdateSource {
     }
 }
 
-/// A filter set carrying an actual account prefilter. `Prefilter::default()`
-/// has every sub-filter unset and converts to an entirely empty
-/// `SubscribeRequest`, so a test built on it would pass on a payload that says
-/// nothing on the wire.
-fn filters_for(ids: &[&str]) -> Filters {
-    let prefilter = Prefilter {
+/// A runtime with one registered slot pipeline, so `TEST_SLOT_FILTER` is a
+/// parser ID that filter updates may name.
+fn filter_update_runtime() -> Runtime<MockFilterUpdateSource> {
+    Runtime::<MockFilterUpdateSource>::builder()
+        .slot(Pipeline::new(SlowSlotParser, [SlowSlotHandler]))
+        .try_build(default_test_config())
+        .unwrap()
+}
+
+/// A prefilter carrying an actual account owner, since `Prefilter::default()`
+/// converts to an entirely empty `SubscribeRequest`. The owner doubles as a
+/// per-test marker.
+fn owned_by(marker: u8) -> Prefilter {
+    Prefilter {
         account: Some(AccountPrefilter {
             accounts: HashSet::new(),
-            owners: HashSet::from([Pubkey::default()]),
+            owners: HashSet::from([Pubkey::new([marker; 32])]),
         }),
         ..Default::default()
-    };
+    }
+}
 
-    Filters::new(
-        ids.iter()
-            .map(|id| ((*id).to_owned(), prefilter.clone()))
-            .collect::<HashMap<_, _>>(),
-    )
+fn owners_of(filters: &Filters, parser_id: &str) -> Option<HashSet<Pubkey>> {
+    filters
+        .get(parser_id)
+        .and_then(|prefilter| prefilter.account.as_ref())
+        .map(|account| account.owners.clone())
 }
 
 #[tokio::test]
-async fn test_filter_updates_reach_a_supporting_source() {
-    let runtime = Runtime::<MockFilterUpdateSource>::builder()
-        .try_build(default_test_config())
-        .unwrap();
+async fn test_handle_filters_are_seeded_from_registered_pipelines() {
+    let runtime = filter_update_runtime();
 
-    // Taken before the run consumes the runtime, and used while it runs, which
-    // is the shape a caller changing filters on a live subscription has.
+    let filters = runtime.handle().filters();
+
+    assert_eq!(filters.parser_ids().collect::<Vec<_>>(), [TEST_SLOT_FILTER]);
+}
+
+#[tokio::test]
+async fn test_update_filters_reaches_the_source_while_it_runs() {
+    let runtime = filter_update_runtime();
     let handle = runtime.handle();
 
     let (result, ()) = tokio::join!(runtime.try_run_async(), async {
         handle
-            .send_filter_update(filters_for(&[SWAPPED_PARSER_ID]))
-            .await
+            .update_filters(|filters| filters.merge(TEST_SLOT_FILTER, owned_by(1)))
             .unwrap();
+
+        // Ending the run is the source's reaction to the last handle going away.
+        drop(handle);
     });
 
     assert_server_hangup(result);
 
-    let received = RECEIVED_FILTER_IDS.lock().unwrap().clone();
+    let received = RECEIVED_FILTERS.lock().unwrap();
+    let marked = received
+        .iter()
+        .filter_map(|filters| owners_of(filters, TEST_SLOT_FILTER))
+        .any(|owners| owners.contains(&Pubkey::new([1; 32])));
+
     assert!(
-        received.contains(&SWAPPED_PARSER_ID.to_owned()),
-        "source never saw the updated filter set, recorded {received:?}"
+        marked,
+        "source never saw the merged owner, recorded {received:?}"
     );
+}
+
+#[tokio::test]
+async fn test_update_filters_advances_the_snapshot() {
+    let runtime = filter_update_runtime();
+    let handle = runtime.handle();
+
+    handle
+        .update_filters(|filters| filters.merge(TEST_SLOT_FILTER, owned_by(2)))
+        .unwrap();
+
+    assert_eq!(
+        owners_of(&handle.filters(), TEST_SLOT_FILTER),
+        Some(HashSet::from([Pubkey::new([2; 32])]))
+    );
+}
+
+#[tokio::test]
+async fn test_update_filters_rejects_an_unregistered_parser() {
+    let runtime = filter_update_runtime();
+    let handle = runtime.handle();
+
+    let result = handle.update_filters(|filters| {
+        filters.insert("test::Unregistered", owned_by(3));
+    });
+
+    assert_eq!(
+        result,
+        Err(FilterUpdateError::UnknownParser(
+            "test::Unregistered".to_owned()
+        ))
+    );
+    assert!(handle.filters().get("test::Unregistered").is_none());
+}
+
+#[tokio::test]
+async fn test_send_filter_update_replaces_the_whole_set() {
+    let runtime = filter_update_runtime();
+    let handle = runtime.handle();
+
+    handle
+        .send_filter_update(Filters::new(HashMap::new()))
+        .unwrap();
+
+    assert_eq!(handle.filters().parser_ids().count(), 0);
+}
+
+#[tokio::test]
+async fn test_reset_filters_restores_the_registered_set() {
+    let runtime = filter_update_runtime();
+    let handle = runtime.handle();
+
+    handle
+        .update_filters(|filters| filters.merge(TEST_SLOT_FILTER, owned_by(4)))
+        .unwrap();
+
+    handle.reset_filters().unwrap();
+
+    let filters = handle.filters();
+    assert_eq!(filters.parser_ids().collect::<Vec<_>>(), [TEST_SLOT_FILTER]);
+    assert!(owners_of(&filters, TEST_SLOT_FILTER).is_none());
 }
 
 #[tokio::test]
@@ -487,35 +563,25 @@ async fn test_filter_updates_rejected_when_source_does_not_support_them() {
         .try_build(default_test_config())
         .unwrap();
 
-    let result = runtime
-        .handle()
-        .send_filter_update(filters_for(&["test::Unsupported"]))
-        .await;
+    let result = runtime.handle().reset_filters();
 
     assert_eq!(result, Err(FilterUpdateError::Unsupported));
 }
 
 #[tokio::test]
 async fn test_filter_updates_rejected_once_the_runtime_is_gone() {
-    let runtime = Runtime::<MockFilterUpdateSource>::builder()
-        .try_build(default_test_config())
-        .unwrap();
-
+    let runtime = filter_update_runtime();
     let handle = runtime.handle();
     drop(runtime);
 
-    let result = handle
-        .send_filter_update(filters_for(&["test::Dropped"]))
-        .await;
+    let result = handle.update_filters(|_| {});
 
     assert_eq!(result, Err(FilterUpdateError::Closed));
 }
 
 #[tokio::test]
 async fn test_source_runs_when_the_filter_update_handle_is_never_taken() {
-    let runtime = Runtime::<MockFilterUpdateSource>::builder()
-        .try_build(default_test_config())
-        .unwrap();
+    let runtime = filter_update_runtime();
 
     assert_server_hangup(runtime.try_run_async().await);
 }

--- a/crates/runtime/src/sources.rs
+++ b/crates/runtime/src/sources.rs
@@ -5,10 +5,7 @@
 
 use async_trait::async_trait;
 use shipstern_core::Filters;
-use tokio::sync::{
-    mpsc::{Receiver, Sender},
-    oneshot,
-};
+use tokio::sync::{mpsc::Sender, oneshot, watch};
 use yellowstone_grpc_proto::{geyser::SubscribeUpdate, tonic};
 
 /// How a source exited.
@@ -51,16 +48,19 @@ pub trait SourceTrait: std::fmt::Debug + Send + Sync + 'static {
 
     /// Whether this source applies filter updates to a live subscription.
     ///
-    /// The runtime checks this before handing a caller the sending half of the
-    /// filter update channel, so a caller wiring updates to a source that
-    /// ignores them finds out at the call site instead of silently sending
-    /// into a void.
+    /// The runtime checks this before accepting an update from a handle, so a
+    /// caller wiring updates to a source that ignores them finds out at the
+    /// call site instead of silently sending into a void.
     ///
     #[must_use]
     fn supports_filter_updates() -> bool { false }
 
-    /// Connect and stream updates, applying filter sets received on
+    /// Connect and stream updates, applying each filter set published on
     /// `filter_updates_rx` to the live subscription.
+    ///
+    /// The slot holds only the newest set, so a source that falls behind sees
+    /// the latest one rather than every intermediate step. `changed()` fails
+    /// once every handle is gone, at which point no further set can arrive.
     ///
     /// The default ignores `filter_updates_rx` and defers to [`Self::connect`],
     /// so a source that cannot change its subscription mid-stream needs no
@@ -71,7 +71,7 @@ pub trait SourceTrait: std::fmt::Debug + Send + Sync + 'static {
         &self,
         tx: Sender<Result<SubscribeUpdate, tonic::Status>>,
         status_tx: oneshot::Sender<SourceExitStatus>,
-        filter_updates_rx: Receiver<Filters>,
+        filter_updates_rx: watch::Receiver<Filters>,
     ) -> Result<(), crate::Error> {
         drop(filter_updates_rx);
 

--- a/crates/runtime/src/sources.rs
+++ b/crates/runtime/src/sources.rs
@@ -46,15 +46,6 @@ pub trait SourceTrait: std::fmt::Debug + Send + Sync + 'static {
         status_tx: oneshot::Sender<SourceExitStatus>,
     ) -> Result<(), crate::Error>;
 
-    /// Whether this source applies filter updates to a live subscription.
-    ///
-    /// The runtime checks this before accepting an update from a handle, so a
-    /// caller wiring updates to a source that ignores them finds out at the
-    /// call site instead of silently sending into a void.
-    ///
-    #[must_use]
-    fn supports_filter_updates() -> bool { false }
-
     /// Connect and stream updates, applying each filter set published on
     /// `filter_updates_rx` to the live subscription.
     ///
@@ -64,8 +55,11 @@ pub trait SourceTrait: std::fmt::Debug + Send + Sync + 'static {
     ///
     /// The default ignores `filter_updates_rx` and defers to [`Self::connect`],
     /// so a source that cannot change its subscription mid-stream needs no
-    /// implementation. Override this together with
-    /// [`Self::supports_filter_updates`].
+    /// implementation. The runtime calls this for every source, because
+    /// generic code cannot pick a method based on which traits `Self` also
+    /// implements. Override it together with implementing
+    /// [`FilterUpdateSource`], which is what lets a caller reach
+    /// [`Runtime::handle`](crate::Runtime::handle) at all.
     ///
     async fn connect_with_filter_updates(
         &self,
@@ -78,3 +72,16 @@ pub trait SourceTrait: std::fmt::Debug + Send + Sync + 'static {
         self.connect(tx, status_tx).await
     }
 }
+
+/// A source that applies filter updates to its live subscription.
+///
+/// Implementing this unlocks [`Runtime::handle`](crate::Runtime::handle) for
+/// runtimes built on the source, so a caller can only take a handle where an
+/// update can take effect. Pair it with an override of
+/// [`SourceTrait::connect_with_filter_updates`], since the marker alone does
+/// not change what the source does with the receiver.
+///
+/// ```rust, ignore
+/// impl FilterUpdateSource for YellowstoneGrpcSource {}
+/// ```
+pub trait FilterUpdateSource: SourceTrait {}

--- a/crates/yellowstone-grpc-source/README.md
+++ b/crates/yellowstone-grpc-source/README.md
@@ -26,32 +26,43 @@ returns next to the update stream, so a caller can change the subscription
 without tearing down the connection and losing messages during the reconnect.
 
 Take a `RuntimeHandle` before running, because `run` and `run_async` both
-consume the runtime, then send updates through the handle from wherever they
-originate. Handles are cheap to clone:
+consume the runtime, then edit the live set through it from wherever the
+change originates. Handles are cheap to clone and share one view of the
+filters. Nothing on the handle awaits, so it works the same from async code
+and from a plain thread beside a blocking `run()`:
 
 ```rust
 let runtime = Runtime::<YellowstoneGrpcSource>::builder()
-    .instruction(Pipeline::new(TokenProgramIxParser, [Handler]))
+    .account(Pipeline::new(TokenProgramAccParser, [Handler]))
     .try_build(config)?;
 
 let handle = runtime.handle();
 tokio::spawn(runtime.run_async());
 
-handle.send_filter_update(new_filters).await?;
+// Widen the account subscription with one more owner.
+let extra = Prefilter::builder().account_owners([new_mint]).build()?;
+handle.update_filters(|filters| filters.merge(TokenProgramAccParser.id(), extra))?;
+
+// Inspect what is live, replace it wholesale, or go back to the start.
+let current = handle.filters();
+handle.send_filter_update(current)?;
+handle.reset_filters()?;
 ```
 
-A thread without a Tokio runtime of its own, such as one sitting next to a
-blocking `run()` call, uses `blocking_send_filter_update` instead.
+`Filters` offers `get`, `insert`, `merge` and `remove` keyed by parser ID for
+building the next set.
 
 Each `Filters` sent replaces the whole subscription rather than adding to it,
 which is what the server does with a mid-stream request, so send the complete
 set every time.
 
-The map keys are parser IDs. A key that matches no registered pipeline still
-changes what the server sends, and the runtime then discards all of it at trace
-level, so take the keys from the parsers you registered. Delivery is best
-effort: a set rejected while the source is between connections is retried once
-the stream recovers, but the sender is not told either way.
+The map keys are parser IDs, and a set naming a parser with no registered
+pipeline is refused with `FilterUpdateError::UnknownParser` before anything is
+sent, since the server would stream data the runtime then discards. Take the
+keys from `Parser::id()`. Only the newest set matters: two updates in quick
+succession may reach the source as the second alone, and a set rejected while
+the source is between connections is retried once the stream recovers, but the
+sender is not told either way.
 
 The server applies the new set promptly, but you see it only once whatever is
 already queued drains, so the delay is however far behind your pipeline already

--- a/crates/yellowstone-grpc-source/README.md
+++ b/crates/yellowstone-grpc-source/README.md
@@ -79,8 +79,9 @@ ends the run. An update the provider will not accept stops the runtime rather
 than leaving the previous subscription in place, so validate against the
 provider's limits before sending one.
 
-`send_filter_update` fails with `FilterUpdateError::Unsupported` for sources
-that do not implement this, which today is every source except gRPC, and with
+`Runtime::handle` exists only for sources implementing `FilterUpdateSource`,
+which today is gRPC alone, so a runtime on any other source has no handle to
+take and the mistake is a compile error. An update fails with
 `FilterUpdateError::Closed` once the runtime has stopped. Whether an update takes effect
 also depends on the provider. Both `yellowstone-grpc-geyser` and `richat` apply
 mid-stream requests to a live subscription, but a deployment can sit behind

--- a/crates/yellowstone-grpc-source/src/lib.rs
+++ b/crates/yellowstone-grpc-source/src/lib.rs
@@ -8,10 +8,7 @@ use shipstern::{
     CommitmentLevel, Error as ShipsternError,
 };
 use shipstern_core::Filters;
-use tokio::sync::{
-    mpsc::{Receiver, Sender},
-    oneshot,
-};
+use tokio::sync::{mpsc::Sender, oneshot, watch};
 use yellowstone_grpc_client::{Backoff, GeyserGrpcClient, ReconnectConfig, SubscribeRequestSink};
 use yellowstone_grpc_proto::{
     geyser::{SubscribeRequest, SubscribeUpdate},
@@ -175,15 +172,23 @@ fn build_subscribe_request(filters: Filters, config: &YellowstoneGrpcConfig) -> 
     request
 }
 
-/// Yield the next filter set, or never resolve when the caller never asked for
-/// updates.
+/// Yield the newest filter set once it changes, or never resolve when the
+/// caller never asked for updates.
 ///
 /// `select!` evaluates a disabled branch's expression before deciding not to
 /// poll it, so this cannot be an `unwrap` guarded by a precondition.
 ///
-async fn next_filter_update(filter_updates_rx: &mut Option<Receiver<Filters>>) -> Option<Filters> {
+/// Returns `None` once every handle is gone and no unseen set remains.
+///
+async fn next_filter_update(
+    filter_updates_rx: &mut Option<watch::Receiver<Filters>>,
+) -> Option<Filters> {
     match filter_updates_rx {
-        Some(rx) => rx.recv().await,
+        Some(rx) => {
+            rx.changed().await.ok()?;
+
+            Some(rx.borrow_and_update().clone())
+        },
         None => std::future::pending().await,
     }
 }
@@ -268,7 +273,7 @@ impl SourceTrait for YellowstoneGrpcSource {
         &self,
         tx: Sender<Result<SubscribeUpdate, Status>>,
         status_tx: oneshot::Sender<SourceExitStatus>,
-        filter_updates_rx: Receiver<Filters>,
+        filter_updates_rx: watch::Receiver<Filters>,
     ) -> Result<(), ShipsternError> {
         self.run(tx, status_tx, Some(filter_updates_rx)).await
     }
@@ -276,7 +281,7 @@ impl SourceTrait for YellowstoneGrpcSource {
 
 impl YellowstoneGrpcSource {
     /// Open the subscription and pump updates until the stream ends, sending
-    /// any filter set that arrives on `filter_updates_rx` to the server so it
+    /// each filter set published on `filter_updates_rx` to the server so it
     /// replaces the live subscription.
     ///
     /// `filter_updates_rx` is `None` when the caller never asked for updates,
@@ -286,7 +291,7 @@ impl YellowstoneGrpcSource {
         &self,
         tx: Sender<Result<SubscribeUpdate, Status>>,
         status_tx: oneshot::Sender<SourceExitStatus>,
-        mut filter_updates_rx: Option<Receiver<Filters>>,
+        mut filter_updates_rx: Option<watch::Receiver<Filters>>,
     ) -> Result<(), ShipsternError> {
         let filters = self.filters.clone();
         let config = self.config.clone();
@@ -389,8 +394,8 @@ impl YellowstoneGrpcSource {
 
                 update = next_filter_update(&mut filter_updates_rx) => {
                     let Some(filters) = update else {
-                        // Nobody holds the sending half any more, so retire the
-                        // branch for the rest of the connection.
+                        // Every handle is gone, so retire the branch for the
+                        // rest of the connection.
                         filter_updates_rx = None;
                         continue;
                     };

--- a/crates/yellowstone-grpc-source/src/lib.rs
+++ b/crates/yellowstone-grpc-source/src/lib.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 use clap::ValueEnum;
 use futures_util::{SinkExt, StreamExt};
 use shipstern::{
-    sources::{SourceExitStatus, SourceTrait},
+    sources::{FilterUpdateSource, SourceExitStatus, SourceTrait},
     CommitmentLevel, Error as ShipsternError,
 };
 use shipstern_core::Filters;
@@ -259,8 +259,6 @@ impl SourceTrait for YellowstoneGrpcSource {
 
     fn new(config: Self::Config, filters: Filters) -> Self { Self { config, filters } }
 
-    fn supports_filter_updates() -> bool { true }
-
     async fn connect(
         &self,
         tx: Sender<Result<SubscribeUpdate, Status>>,
@@ -278,6 +276,8 @@ impl SourceTrait for YellowstoneGrpcSource {
         self.run(tx, status_tx, Some(filter_updates_rx)).await
     }
 }
+
+impl FilterUpdateSource for YellowstoneGrpcSource {}
 
 impl YellowstoneGrpcSource {
     /// Open the subscription and pump updates until the stream ends, sending


### PR DESCRIPTION
## Summary

Stacked on #302. Resolves the open thread there asking how a caller reads the current filters, patches them, and sends the result.

`RuntimeHandle::send_filter_update` took a complete `Filters` with no way to see what was live, so every change meant rebuilding the whole set from parser IDs by hand. An ID with no registered pipeline was accepted and its data silently discarded downstream. And the handle was async for no structural reason.

```rust
let handle = runtime.handle();
tokio::spawn(runtime.run_async());

// Widen one parser's subscription.
let extra = Prefilter::builder().account_owners([new_mint]).build()?;
handle.update_filters(|filters| filters.merge(TokenProgramAccParser.id(), extra))?;

// Inspect, replace wholesale, or go back to the start.
let current = handle.filters();
handle.send_filter_update(current)?;
handle.reset_filters()?;
```

## What changed

**Core.** `Filters` gains `get`, `parser_ids`, `insert`, `merge` and `remove`, keyed by parser ID. `merge` unions through the existing `Prefilter::merge` and inserts when absent.

**Handle.** Every handle shares one `FilterState`, created by the builder from the registered pipelines.

- `filters()` returns the last set handed to the source, seeded from the pipelines.
- `update_filters(FnOnce(&mut Filters))` edits a copy under a lock, validates, and publishes. Concurrent edits from any handle serialise, so none is lost.
- `send_filter_update` is whole-set replacement on top of `update_filters`. `reset_filters` publishes the initial set.
- `FilterUpdateError::UnknownParser(String)` refuses any set naming a parser with no registered pipeline, before anything is sent. This replaces the trace-level footgun the old docs had to warn about.

**Transport.** The bounded `mpsc` is replaced by a `tokio::sync::watch` slot. Nothing in an update waits on I/O, and the documented semantics already said a newer set supersedes an older one, which is what `watch` provides. The slot is both the transport and the record of the last set handed off, so `filters()` reads the same value the source reads. Every handle method is now synchronous and works from async code and a plain thread beside a blocking `run()` alike, so `blocking_send_filter_update` is gone.

**Trait.** `connect_with_filter_updates` takes a `watch::Receiver<Filters>`. The gRPC source awaits `changed()` then reads `borrow_and_update()`; its held-set retry across reconnect windows is unchanged. The other five sources use the default and needed no change.

**Docs** were condensed to a short semantics list on the `RuntimeHandle` type plus one example per method.

## Behaviour to review

- **Coalescing is now guaranteed.** Two updates faster than the source polls reach it as the second alone. The old docs permitted this; the primitive now enforces it. Complete sets make it harmless.
- **No back-pressure signal.** A bounded queue would eventually stall a sender if the source stopped draining. `watch` never does. The source polls the receiver continuously in its `select!` loop, and the docs already say `Ok(())` is not an acknowledgement, so little is lost, but it is a real difference.
- **`filters()` means "last set handed off"**, not "what the server is serving". There is no acknowledgement from the source, so that is the only honest reading today.

## Testing

Clippy `-Dwarnings` clean on core, runtime, gRPC and fumarole sources. `cargo check --workspace --all-targets` clean. Nightly `cargo fmt --check` clean.

Runtime tests cover seeding from pipelines, delivery to a running source, snapshot advancing, unknown parser refused with the set untouched, whole-set replacement including an empty set, reset, unsupported source, and closed runtime. The mock source loops on `changed()` until the last handle drops, and `changed()` still yields an unseen value after the final sender is gone, so the tests are race-free. Ran the filter tests ten times with no flakes. Core has four unit tests for the `Filters` helpers.
