### PR TITLE
Gate Runtime::handle on a FilterUpdateSource marker trait

### DIFF
--- a/crates/runtime/src/handle.rs
+++ b/crates/runtime/src/handle.rs
@@ -8,10 +8,6 @@ use tokio::sync::watch;
 /// Why a filter update never reached the source.
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum FilterUpdateError {
-    /// The source behind the runtime cannot change its subscription
-    /// mid-stream, so no update could ever take effect.
-    #[error("the source does not support filter updates")]
-    Unsupported,
     /// The runtime has stopped, or was dropped without being run, so nothing
     /// is left to apply the set.
     #[error("the runtime is no longer running")]
@@ -75,8 +71,10 @@ impl FilterState {
 ///
 /// [`Runtime::run`](crate::Runtime::run) and its variants take the runtime by
 /// value, so take the handle with [`Runtime::handle`](crate::Runtime::handle)
-/// first. Handles are cheap to clone, share one view of the filters, and work
-/// from async and plain threads alike since nothing here awaits.
+/// first. It exists only for sources implementing
+/// [`FilterUpdateSource`](crate::sources::FilterUpdateSource). Handles are
+/// cheap to clone, share one view of the filters, and work from async and
+/// plain threads alike since nothing here awaits.
 ///
 /// ```rust, ignore
 /// let runtime = Runtime::<YellowstoneGrpcSource>::builder()
@@ -111,17 +109,11 @@ impl FilterState {
 ///   ends the run. Under `run` and `run_async` that exits the process.
 #[derive(Debug, Clone)]
 pub struct RuntimeHandle {
-    /// Whether the source behind the runtime applies filter updates, so a
-    /// send fails at the call site instead of vanishing into a slot nobody
-    /// reads.
-    supported: bool,
     state: Arc<FilterState>,
 }
 
 impl RuntimeHandle {
-    pub(crate) fn new(supported: bool, state: Arc<FilterState>) -> Self {
-        Self { supported, state }
-    }
+    pub(crate) fn new(state: Arc<FilterState>) -> Self { Self { state } }
 
     /// The last filter set handed to the source, seeded from the registered
     /// pipelines.
@@ -156,10 +148,6 @@ impl RuntimeHandle {
     ///
     pub fn update_filters<F>(&self, edit: F) -> Result<(), FilterUpdateError>
     where F: FnOnce(&mut Filters) {
-        if !self.supported {
-            return Err(FilterUpdateError::Unsupported);
-        }
-
         let _serialised = self
             .state
             .update_lock

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -49,7 +49,10 @@ pub use shipstern_core::CommitmentLevel;
 pub use util::*;
 use yellowstone_grpc_proto::geyser::SubscribeUpdate;
 
-use crate::{builder::RuntimeBuilder, sources::SourceTrait};
+use crate::{
+    builder::RuntimeBuilder,
+    sources::{FilterUpdateSource, SourceTrait},
+};
 
 /// An error thrown by the Shipstern runtime.
 #[derive(Debug, thiserror::Error)]
@@ -96,15 +99,17 @@ pub struct Runtime<S: SourceTrait> {
 impl<S: SourceTrait> Runtime<S> {
     /// Create a new runtime builder.
     pub fn builder() -> RuntimeBuilder<S> { RuntimeBuilder::<S>::default() }
+}
 
+impl<S: FilterUpdateSource> Runtime<S> {
     /// Create a handle for changing this runtime's subscription once it is
     /// running.
     ///
-    /// [`Self::run`], [`Self::try_run`], [`Self::run_async`] and
+    /// Only available when the source implements [`FilterUpdateSource`], so a
+    /// runtime whose source cannot change its subscription has no handle to
+    /// take. [`Self::run`], [`Self::try_run`], [`Self::run_async`] and
     /// [`Self::try_run_async`] all consume the runtime, so take the handle
-    /// first. Every handle shares one view of the filters, and one taken from
-    /// a source that cannot change its subscription fails each update with
-    /// [`FilterUpdateError::Unsupported`].
+    /// first. Every handle shares one view of the filters.
     ///
     /// ```rust, ignore
     /// let runtime = Runtime::<YellowstoneGrpcSource>::builder()
@@ -117,9 +122,7 @@ impl<S: SourceTrait> Runtime<S> {
     /// handle.update_filters(|filters| filters.merge(TokenProgramAccParser.id(), extra_owner))?;
     /// ```
     #[must_use]
-    pub fn handle(&self) -> RuntimeHandle {
-        RuntimeHandle::new(S::supports_filter_updates(), Arc::clone(&self.filter_state))
-    }
+    pub fn handle(&self) -> RuntimeHandle { RuntimeHandle::new(Arc::clone(&self.filter_state)) }
 }
 impl<S: SourceTrait> Runtime<S> {
     /// Create a new Tokio runtime and run the Shipstern runtime within it,

--- a/crates/runtime/src/runtime_tests.rs
+++ b/crates/runtime/src/runtime_tests.rs
@@ -20,7 +20,7 @@ use yellowstone_grpc_proto::{
 
 use crate::{
     config::{BufferConfig, NullConfig, ShipsternConfig},
-    sources::{SourceExitStatus, SourceTrait},
+    sources::{FilterUpdateSource, SourceExitStatus, SourceTrait},
     Error, FilterUpdateError, Handler, Pipeline, Runtime,
 };
 
@@ -393,8 +393,6 @@ impl SourceTrait for MockFilterUpdateSource {
 
     fn new(_: NullConfig, _: Filters) -> Self { Self }
 
-    fn supports_filter_updates() -> bool { true }
-
     async fn connect(
         &self,
         tx: Sender<Result<SubscribeUpdate, tonic::Status>>,
@@ -429,6 +427,8 @@ impl SourceTrait for MockFilterUpdateSource {
         Ok(())
     }
 }
+
+impl FilterUpdateSource for MockFilterUpdateSource {}
 
 /// A runtime with one registered slot pipeline, so `TEST_SLOT_FILTER` is a
 /// parser ID that filter updates may name.
@@ -555,17 +555,6 @@ async fn test_reset_filters_restores_the_registered_set() {
     let filters = handle.filters();
     assert_eq!(filters.parser_ids().collect::<Vec<_>>(), [TEST_SLOT_FILTER]);
     assert!(owners_of(&filters, TEST_SLOT_FILTER).is_none());
-}
-
-#[tokio::test]
-async fn test_filter_updates_rejected_when_source_does_not_support_them() {
-    let runtime = Runtime::<MockStreamEndSource>::builder()
-        .try_build(default_test_config())
-        .unwrap();
-
-    let result = runtime.handle().reset_filters();
-
-    assert_eq!(result, Err(FilterUpdateError::Unsupported));
 }
 
 #[tokio::test]

--- a/crates/runtime/src/sources.rs
+++ b/crates/runtime/src/sources.rs
@@ -46,15 +46,6 @@ pub trait SourceTrait: std::fmt::Debug + Send + Sync + 'static {
         status_tx: oneshot::Sender<SourceExitStatus>,
     ) -> Result<(), crate::Error>;
 
-    /// Whether this source applies filter updates to a live subscription.
-    ///
-    /// The runtime checks this before accepting an update from a handle, so a
-    /// caller wiring updates to a source that ignores them finds out at the
-    /// call site instead of silently sending into a void.
-    ///
-    #[must_use]
-    fn supports_filter_updates() -> bool { false }
-
     /// Connect and stream updates, applying each filter set published on
     /// `filter_updates_rx` to the live subscription.
     ///
@@ -64,8 +55,11 @@ pub trait SourceTrait: std::fmt::Debug + Send + Sync + 'static {
     ///
     /// The default ignores `filter_updates_rx` and defers to [`Self::connect`],
     /// so a source that cannot change its subscription mid-stream needs no
-    /// implementation. Override this together with
-    /// [`Self::supports_filter_updates`].
+    /// implementation. The runtime calls this for every source, because
+    /// generic code cannot pick a method based on which traits `Self` also
+    /// implements. Override it together with implementing
+    /// [`FilterUpdateSource`], which is what lets a caller reach
+    /// [`Runtime::handle`](crate::Runtime::handle) at all.
     ///
     async fn connect_with_filter_updates(
         &self,
@@ -78,3 +72,16 @@ pub trait SourceTrait: std::fmt::Debug + Send + Sync + 'static {
         self.connect(tx, status_tx).await
     }
 }
+
+/// A source that applies filter updates to its live subscription.
+///
+/// Implementing this unlocks [`Runtime::handle`](crate::Runtime::handle) for
+/// runtimes built on the source, so a caller can only take a handle where an
+/// update can take effect. Pair it with an override of
+/// [`SourceTrait::connect_with_filter_updates`], since the marker alone does
+/// not change what the source does with the receiver.
+///
+/// ```rust, ignore
+/// impl FilterUpdateSource for YellowstoneGrpcSource {}
+/// ```
+pub trait FilterUpdateSource: SourceTrait {}

--- a/crates/yellowstone-grpc-source/README.md
+++ b/crates/yellowstone-grpc-source/README.md
@@ -79,8 +79,9 @@ ends the run. An update the provider will not accept stops the runtime rather
 than leaving the previous subscription in place, so validate against the
 provider's limits before sending one.
 
-`send_filter_update` fails with `FilterUpdateError::Unsupported` for sources
-that do not implement this, which today is every source except gRPC, and with
+`Runtime::handle` exists only for sources implementing `FilterUpdateSource`,
+which today is gRPC alone, so a runtime on any other source has no handle to
+take and the mistake is a compile error. An update fails with
 `FilterUpdateError::Closed` once the runtime has stopped. Whether an update takes effect
 also depends on the provider. Both `yellowstone-grpc-geyser` and `richat` apply
 mid-stream requests to a live subscription, but a deployment can sit behind

--- a/crates/yellowstone-grpc-source/src/lib.rs
+++ b/crates/yellowstone-grpc-source/src/lib.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 use clap::ValueEnum;
 use futures_util::{SinkExt, StreamExt};
 use shipstern::{
-    sources::{SourceExitStatus, SourceTrait},
+    sources::{FilterUpdateSource, SourceExitStatus, SourceTrait},
     CommitmentLevel, Error as ShipsternError,
 };
 use shipstern_core::Filters;
@@ -259,8 +259,6 @@ impl SourceTrait for YellowstoneGrpcSource {
 
     fn new(config: Self::Config, filters: Filters) -> Self { Self { config, filters } }
 
-    fn supports_filter_updates() -> bool { true }
-
     async fn connect(
         &self,
         tx: Sender<Result<SubscribeUpdate, Status>>,
@@ -278,6 +276,8 @@ impl SourceTrait for YellowstoneGrpcSource {
         self.run(tx, status_tx, Some(filter_updates_rx)).await
     }
 }
+
+impl FilterUpdateSource for YellowstoneGrpcSource {}
 
 impl YellowstoneGrpcSource {
     /// Open the subscription and pump updates until the stream ends, sending


### PR DESCRIPTION
## Summary

Stacked on #305, which is stacked on #302. Addresses the #302 thread asking for a `SourceTrait + FilterUpdateTrait` split so the filter update capability does not expand the trait every source implements.

`supports_filter_updates()` advertised the capability as a runtime bool. A handle taken from a source that ignores updates existed and failed every call with `FilterUpdateError::Unsupported`. This moves the capability to the type level.

```rust
/// A source that applies filter updates to its live subscription.
pub trait FilterUpdateSource: SourceTrait {}

impl FilterUpdateSource for YellowstoneGrpcSource {}

impl<S: FilterUpdateSource> Runtime<S> {
    pub fn handle(&self) -> RuntimeHandle { ... }
}
```

A runtime on any other source has no `handle()` to call, so wiring updates to a source that cannot apply them is now a compile error instead of a runtime one.

## What changed

- New marker trait `sources::FilterUpdateSource: SourceTrait`, implemented by the gRPC source and the test mock.
- `Runtime::handle` moves into an `impl<S: FilterUpdateSource>` block.
- Removed: `SourceTrait::supports_filter_updates`, `FilterUpdateError::Unsupported`, the `supported` flag on `RuntimeHandle`, and the test that exercised the runtime check.
- Docs on `connect_with_filter_updates` and on the marker say to pair them.

## Why the dispatch method stays on `SourceTrait`

The runtime's `try_run_async` is generic over `S: SourceTrait` and has to call something to start the source. Rust has no specialization, so generic code cannot branch on whether `S` also implements `FilterUpdateSource`. The method the runtime calls therefore has to live on the base trait with a default that defers to `connect`. What can move to the type level is the part callers see, and that is what this PR moves.

The alternatives considered and rejected:

- Putting the method on the subtrait and having `handle()` stash a boxed connector for `try_run_async` to use. Gives a clean trait boundary, but makes which connect method runs depend on whether anyone called `handle()`, and needs interior mutability on the runtime.
- Adding the receiver to `connect` itself. One method, no default pair, but breaks all fourteen `SourceTrait` implementations including out-of-tree ones. Worth revisiting only alongside a wider `SourceTrait` redesign, such as the one discussed for the stub `new` boilerplate.

## Known gap

The marker and the method override are not tied together. A source can implement the marker without overriding `connect_with_filter_updates`, in which case updates are silently dropped. The docs on both say to pair them, and the gRPC source is the only implementor today.

## Testing

Clippy `-Dwarnings` clean on core, runtime, gRPC and fumarole sources. `cargo check --workspace --all-targets` clean, confirming the other five sources compile unchanged. Nightly `cargo fmt --check` clean. Runtime tests pass with the unsupported-source test removed, since that case no longer compiles.
