### PR TITLE
chore(runtime): downgrade parse/handle spans to debug level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- `shipstern.parse` and `shipstern.handle` are now `debug` spans instead of `info`, so they no longer spam `info`-level trace output ([#313](https://github.com/solana-rpc/shipstern/pull/313) by @ultrasilicon).
+
 ## [0.9.0] - 2026-09-08
 
 ### Changed

--- a/crates/runtime/src/handler.rs
+++ b/crates/runtime/src/handler.rs
@@ -159,7 +159,7 @@ where
         let parsed = match self
             .0
             .parse(value)
-            .instrument(tracing::info_span!("shipstern.parse",))
+            .instrument(tracing::debug_span!("shipstern.parse",))
             .await
         {
             Ok(p) => p,
@@ -175,7 +175,7 @@ where
             .into_iter()
             .map(|h| async move {
                 h.handle(parsed, value)
-                    .instrument(tracing::info_span!("shipstern.handle",))
+                    .instrument(tracing::debug_span!("shipstern.handle",))
                     .await
             })
             .collect::<futures_util::stream::FuturesUnordered<_>>()


### PR DESCRIPTION
## Summary

Info spans from `shipstern.parse` and `shipstern.parse` spammed our system.
I think these can be categorized as debug spans?

## Approach

Simple:

```diff
--- a/crates/runtime/src/handler.rs
+++ b/crates/runtime/src/handler.rs
@@ -159,7 +159,7 @@ where
         let parsed = match self
             .0
             .parse(value)
-            .instrument(tracing::info_span!("shipstern.parse",))
+            .instrument(tracing::debug_span!("shipstern.parse",))
             .await
         {
             Ok(p) => p,
@@ -175,7 +175,7 @@ where
             .into_iter()
             .map(|h| async move {
                 h.handle(parsed, value)
-                    .instrument(tracing::info_span!("shipstern.handle",))
+                    .instrument(tracing::debug_span!("shipstern.handle",))
                     .await
             })
```

## Testing

`cargo check --workspace --all-targets`, `cargo clippy --all-targets --tests
-Dwarnings`, `cargo test --workspace --lib --tests` (286 passed), `cargo fmt --check`.
