### PR TITLE
docs(readme): bump codegen macro dependency snippets to 0.9.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,8 +119,8 @@ To use it, add the following dependencies to your `Cargo.toml`:
 ```toml
 [dependencies]
 borsh = "^1.0.0"
-shipstern-parser = { version = "0.8.0" }
-shipstern-proc-macro = { version = "0.8.0" }
+shipstern-parser = { version = "0.9.0" }
+shipstern-proc-macro = { version = "0.9.0" }
 ```
 
 Then, import and invoke the macro in your code. Specify the path to your Codama JSON IDL file relative to your crate root:

--- a/crates/proc-macro/README.md
+++ b/crates/proc-macro/README.md
@@ -9,8 +9,8 @@ Add this crate to your `Cargo.toml` (usually as a `proc-macro` dependency):
 ```toml
 [dependencies]
 borsh = { version = "^1.0.0", features = ["derive"] }
-shipstern-parser = { version = "0.8.0" }
-shipstern-proc-macro = { version = "0.8.0" }
+shipstern-parser = { version = "0.9.0" }
+shipstern-proc-macro = { version = "0.9.0" }
 ```
 
 Then, in your code:


### PR DESCRIPTION
The Codegen Macro usage snippets in the root README and `crates/proc-macro/README.md` still pinned `shipstern-parser` and `shipstern-proc-macro` at 0.8.0. Bump them to 0.9.0 to match the crates published on 2026-09-08.

The example crates under `examples/` are untouched: they declare their shipstern dependencies with `workspace = true` and already resolve to 0.9.0.