### PR TITLE
chore(release): 0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
+## [0.10.0] - 2026-09-10
 
 ### Changed
 
@@ -174,5 +174,6 @@ and adheres to [Semantic Versioning](https://semver.org/).
 
 - Make `AccountKeys` get method public (https://github.com/rpcpool/yellowstone-vixen/pull/60)
 
-[Unreleased]: https://github.com/solana-rpc/shipstern/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/solana-rpc/shipstern/compare/v0.10.0...HEAD
+[0.10.0]: https://github.com/solana-rpc/shipstern/releases/tag/v0.10.0
 [0.2.0]: https://github.com/solana-rpc/shipstern/releases/tag/v0.2.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6789,7 +6789,7 @@ checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shipstern"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "async-trait",
  "clap 4.6.6",
@@ -6811,7 +6811,7 @@ dependencies = [
 
 [[package]]
 name = "shipstern-block-coordinator"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "async-trait",
  "bs58",
@@ -6835,7 +6835,7 @@ dependencies = [
 
 [[package]]
 name = "shipstern-block-meta-parser"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "prost 0.14.4",
  "prost-types 0.14.4",
@@ -6848,7 +6848,7 @@ dependencies = [
 
 [[package]]
 name = "shipstern-bpf-loader-parser"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "bincode",
  "prost 0.14.4",
@@ -6864,7 +6864,7 @@ dependencies = [
 
 [[package]]
 name = "shipstern-core"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "base64 0.22.1",
  "borsh 1.8.1",
@@ -6933,7 +6933,7 @@ dependencies = [
 
 [[package]]
 name = "shipstern-example-jetstreamer"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "bs58",
@@ -6991,7 +6991,7 @@ dependencies = [
 
 [[package]]
 name = "shipstern-jetstream-source"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -7028,7 +7028,7 @@ dependencies = [
 
 [[package]]
 name = "shipstern-kafka-sink"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "futures 0.3.34",
  "mockito",
@@ -7047,7 +7047,7 @@ dependencies = [
 
 [[package]]
 name = "shipstern-mock"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "futures 0.3.34",
  "regex",
@@ -7063,7 +7063,7 @@ dependencies = [
 
 [[package]]
 name = "shipstern-parser"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -7078,7 +7078,7 @@ dependencies = [
 
 [[package]]
 name = "shipstern-proc-macro"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -7095,7 +7095,7 @@ dependencies = [
 
 [[package]]
 name = "shipstern-proto"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "prost 0.14.4",
  "prost-types 0.14.4",
@@ -7108,7 +7108,7 @@ dependencies = [
 
 [[package]]
 name = "shipstern-slot-parser"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "shipstern-core",
  "shipstern-mock",
@@ -7117,7 +7117,7 @@ dependencies = [
 
 [[package]]
 name = "shipstern-solana-rpc-source"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "async-trait",
  "clap 4.6.6",
@@ -7135,7 +7135,7 @@ dependencies = [
 
 [[package]]
 name = "shipstern-solana-snapshot-source"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "agave-snapshots",
  "async-trait",
@@ -7162,7 +7162,7 @@ dependencies = [
 
 [[package]]
 name = "shipstern-spl-token-extensions-parser"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "borsh 1.8.1",
  "bs58",
@@ -7189,7 +7189,7 @@ dependencies = [
 
 [[package]]
 name = "shipstern-spl-token-parser"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "bs58",
  "bytemuck",
@@ -7212,7 +7212,7 @@ dependencies = [
 
 [[package]]
 name = "shipstern-stake-pool-parser"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "borsh 1.8.1",
  "bs58",
@@ -7231,7 +7231,7 @@ dependencies = [
 
 [[package]]
 name = "shipstern-stream"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "async-trait",
  "clap 4.6.6",
@@ -7262,7 +7262,7 @@ dependencies = [
 
 [[package]]
 name = "shipstern-yellowstone-fumarole-source"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "async-trait",
  "bytesize 2.7.0",
@@ -7281,7 +7281,7 @@ dependencies = [
 
 [[package]]
 name = "shipstern-yellowstone-grpc-source"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "async-trait",
  "clap 4.6.6",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ resolver = "2"
 authors = ["Triton One", "ABK-Labs", "Jupiter Exchange"]
 edition = "2024"
 license = "MIT"
-version = "0.9.0"
+version = "0.10.0"
 repository = "https://github.com/solana-rpc/shipstern"
 publish = false
 
@@ -114,31 +114,31 @@ yellowstone-grpc-proto = { version = "12.6", default-features = false }
 rdkafka = { version = "0.36", features = ["cmake-build", "ssl", "zstd"] }
 reqwest = { version = "0.12", features = ["json", "blocking", "stream"] }
 
-shipstern = { path = "crates/runtime", version = "0.9.0" }
-shipstern-proc-macro = { path = "crates/proc-macro", version = "0.9.0" }
-shipstern-stream = { path = "crates/stream", version = "0.9.0" }
-shipstern-core = { path = "crates/core", version = "0.9.0" }
-shipstern-mock = { path = "crates/mock", version = "0.9.0" }
-shipstern-parser = { path = "crates/parser", version = "0.9.0" }
-shipstern-proto = { path = "crates/proto", version = "0.9.0" }
+shipstern = { path = "crates/runtime", version = "0.10.0" }
+shipstern-proc-macro = { path = "crates/proc-macro", version = "0.10.0" }
+shipstern-stream = { path = "crates/stream", version = "0.10.0" }
+shipstern-core = { path = "crates/core", version = "0.10.0" }
+shipstern-mock = { path = "crates/mock", version = "0.10.0" }
+shipstern-parser = { path = "crates/parser", version = "0.10.0" }
+shipstern-proto = { path = "crates/proto", version = "0.10.0" }
 
 # Parsers
-shipstern-bpf-loader-parser = { path = "crates/bpf-loader-parser", version = "0.9.0" }
-shipstern-spl-token-extensions-parser = { path = "crates/spl-token-extensions-parser", version = "0.9.0" }
-shipstern-spl-token-parser = { path = "crates/spl-token-parser", version = "0.9.0" }
-shipstern-block-meta-parser = { path = "crates/block-meta-parser", version = "0.9.0" }
-shipstern-slot-parser = { path = "crates/slot-parser", version = "0.9.0" }
-shipstern-stake-pool-parser = { path = "crates/stake-pool-parser", version = "0.9.0" }
+shipstern-bpf-loader-parser = { path = "crates/bpf-loader-parser", version = "0.10.0" }
+shipstern-spl-token-extensions-parser = { path = "crates/spl-token-extensions-parser", version = "0.10.0" }
+shipstern-spl-token-parser = { path = "crates/spl-token-parser", version = "0.10.0" }
+shipstern-block-meta-parser = { path = "crates/block-meta-parser", version = "0.10.0" }
+shipstern-slot-parser = { path = "crates/slot-parser", version = "0.10.0" }
+shipstern-stake-pool-parser = { path = "crates/stake-pool-parser", version = "0.10.0" }
 
 # Sources
-shipstern-solana-rpc-source = { path = "crates/solana-rpc-source", version = "0.9.0" }
-shipstern-yellowstone-grpc-source = { path = "crates/yellowstone-grpc-source", version = "0.9.0" }
-shipstern-yellowstone-fumarole-source = { path = "crates/yellowstone-fumarole-source", version = "0.9.0" }
-shipstern-solana-snapshot-source = { path = "crates/solana-snapshot-source", version = "0.9.0" }
-shipstern-jetstream-source = { path = "crates/jetstreamer-source", version = "0.9.0" }
+shipstern-solana-rpc-source = { path = "crates/solana-rpc-source", version = "0.10.0" }
+shipstern-yellowstone-grpc-source = { path = "crates/yellowstone-grpc-source", version = "0.10.0" }
+shipstern-yellowstone-fumarole-source = { path = "crates/yellowstone-fumarole-source", version = "0.10.0" }
+shipstern-solana-snapshot-source = { path = "crates/solana-snapshot-source", version = "0.10.0" }
+shipstern-jetstream-source = { path = "crates/jetstreamer-source", version = "0.10.0" }
 
 # Coordinators
-shipstern-block-coordinator = { path = "crates/block-coordinator", version = "0.9.0" }
+shipstern-block-coordinator = { path = "crates/block-coordinator", version = "0.10.0" }
 
 # Sinks
-shipstern-kafka-sink = { path = "crates/kafka-sink", version = "0.9.0" }
+shipstern-kafka-sink = { path = "crates/kafka-sink", version = "0.10.0" }

--- a/README.md
+++ b/README.md
@@ -119,8 +119,8 @@ To use it, add the following dependencies to your `Cargo.toml`:
 ```toml
 [dependencies]
 borsh = "^1.0.0"
-shipstern-parser = { version = "0.9.0" }
-shipstern-proc-macro = { version = "0.9.0" }
+shipstern-parser = { version = "0.10.0" }
+shipstern-proc-macro = { version = "0.10.0" }
 ```
 
 Then, import and invoke the macro in your code. Specify the path to your Codama JSON IDL file relative to your crate root:

--- a/crates/proc-macro/README.md
+++ b/crates/proc-macro/README.md
@@ -9,8 +9,8 @@ Add this crate to your `Cargo.toml` (usually as a `proc-macro` dependency):
 ```toml
 [dependencies]
 borsh = { version = "^1.0.0", features = ["derive"] }
-shipstern-parser = { version = "0.9.0" }
-shipstern-proc-macro = { version = "0.9.0" }
+shipstern-parser = { version = "0.10.0" }
+shipstern-proc-macro = { version = "0.10.0" }
 ```
 
 Then, in your code:


### PR DESCRIPTION
Cuts the 0.10.0 release.

- `CHANGELOG.md`: Unreleased becomes `[0.10.0] - 2026-09-10`; compare and release-tag links added.
- `Cargo.toml` / `Cargo.lock`: workspace version and all internal `shipstern-*` pins bumped from 0.9.0 to 0.10.0 (lockfile refreshed with `cargo update --workspace`, workspace crates only).
- `README.md`, `crates/proc-macro/README.md`: codegen dependency snippets bumped to 0.10.0.

Note: the 0.9.0 Deprecated entry says `cpi_event_discriminator` / `cpi_event_payload_offset` are removed in 0.10, but they are still accepted by the macro. That removal was not part of this cycle; the 0.9.0 wording is left as-is pending a decision on whether it slips to 0.11.