### PR TITLE
docs(codama): document the proc-macro workflow and fix the dependency snippets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Changed
+
+- `shipstern-proc-macro`: the deprecation note on `cpi_event_discriminator` and `cpi_event_payload_offset` no longer names a removal version. The 0.9.0 entry below promised their removal for the 0.10 release, which did not happen; they are still parsed and honoured as the fallback for IDLs that declare no CPI event envelope, and no removal version is established. That entry is corrected in place, since it promised a removal consumers may have planned around.
+
 ## [0.10.0] - 2026-09-10
 
 ### Changed
@@ -34,7 +40,7 @@ and adheres to [Semantic Versioning](https://semver.org/).
 
 ### Deprecated
 
-- `shipstern-proc-macro`: the `cpi_event_discriminator` and `cpi_event_payload_offset` macro arguments are ignored, with a deprecation warning at the call site, when the IDL declares a CPI event envelope. They still apply to IDLs that declare none. Both arguments are removed in 0.10 ([#299](https://github.com/solana-rpc/shipstern/pull/299) by @senzenn).
+- `shipstern-proc-macro`: the `cpi_event_discriminator` and `cpi_event_payload_offset` macro arguments are ignored, with a deprecation warning at the call site, when the IDL declares a CPI event envelope. They still apply to IDLs that declare none. No removal version is currently established ([#299](https://github.com/solana-rpc/shipstern/pull/299) by @senzenn).
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -118,10 +118,21 @@ To use it, add the following dependencies to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-borsh = "^1.0.0"
+borsh = { version = "^1.0.0", features = ["derive"] }
+shipstern-core = { version = "0.10.0" }
 shipstern-parser = { version = "0.10.0" }
 shipstern-proc-macro = { version = "0.10.0" }
 ```
+
+The generated code imports `shipstern_core` and derives `BorshDeserialize` / `BorshSerialize`, so both `shipstern-core` and the Borsh `derive` feature are required.
+
+To parse events, including self-CPI events, enable the `program-events` feature. Note that it also changes `InstructionParser::Output` from `Instructions` to `ProgramEventOutput`:
+
+```toml
+shipstern-proc-macro = { version = "0.10.0", features = ["program-events"] }
+```
+
+The macro reads a **Codama** JSON IDL, not a raw Anchor IDL, and it must carry the full node structure that `codama-nodes` requires. See [Generate a Shipstern Parser from a Codama IDL](./docs/codama-parser-generation.md).
 
 Then, import and invoke the macro in your code. Specify the path to your Codama JSON IDL file relative to your crate root:
 
@@ -208,7 +219,7 @@ This applies to every `cargo` invocation inside this workspace. The file is giti
 - [**Mock Testing for Parsers**](./crates/mock/README.md): Load and replay devnet accounts or transactions offline.
 - [**Usage Examples**](./examples/): A variety of example projects that demonstrate how to use the features.
 - [**Example Shipstern Configuration**](./Shipstern.example.toml): Starter TOML file for pipeline configuration.
-- [**Generate Parsers from IDL**](./docs/codama-parser-generation.md): Use Codama to automatically generate Shipstern parsers from Anchor or custom IDL files.
+- [**Generate Parsers from IDL**](./docs/codama-parser-generation.md): Generate a Shipstern parser from a Codama IDL with the `include_shipstern_parser!` macro, including how to declare self-CPI event envelopes in Codama.
 
 ## Maintainers
 

--- a/crates/proc-macro/README.md
+++ b/crates/proc-macro/README.md
@@ -9,9 +9,12 @@ Add this crate to your `Cargo.toml` (usually as a `proc-macro` dependency):
 ```toml
 [dependencies]
 borsh = { version = "^1.0.0", features = ["derive"] }
+shipstern-core = { version = "0.10.0" }
 shipstern-parser = { version = "0.10.0" }
 shipstern-proc-macro = { version = "0.10.0" }
 ```
+
+`shipstern-core` is required: the generated code imports it directly.
 
 Then, in your code:
 
@@ -22,7 +25,19 @@ use shipstern_proc_macro::include_shipstern_parser;
 include_shipstern_parser!("path/to/idl.json");
 ```
 
-This macro will generate Rust modules containing type-safe account and instruction parsers for the specified Solana program.
+This macro will generate Rust modules containing type-safe account and instruction parsers for the specified Solana program. The input is a **Codama** JSON IDL, not a raw Anchor IDL, and it must carry the full node structure that `codama-nodes` requires. See [the Codama parser guide](../../docs/codama-parser-generation.md).
+
+## Events and self-CPI events
+
+Event parsing is gated behind the `program-events` feature. Without it the macro emits no event types, whatever the IDL declares:
+
+```toml
+shipstern-proc-macro = { version = "0.10.0", features = ["program-events"] }
+```
+
+Enabling it changes `InstructionParser::Output` from `Instructions` to `ProgramEventOutput`, which carries the decoded instruction alongside any events found on inner instructions. Because that is a public type, the feature propagates through Cargo's feature unification to every crate sharing the dependency.
+
+See [the Codama parser guide](../../docs/codama-parser-generation.md) for how to declare a self-CPI event envelope in the IDL.
 
 ## Serde support
 

--- a/crates/proc-macro/src/lib.rs
+++ b/crates/proc-macro/src/lib.rs
@@ -29,6 +29,38 @@ pub fn shipstern(attr: TokenStream, item: TokenStream) -> TokenStream {
         .into()
 }
 
+///
+/// Generate a Shipstern parser from a Codama JSON IDL at compile time.
+///
+/// The path is resolved relative to the invoking crate's root
+/// (`CARGO_MANIFEST_DIR`). Nothing is written to disk. The generated module is
+/// named after the program and carries `PROGRAM_ID`, `InstructionParser`,
+/// `AccountParser`, and the argument and account types.
+///
+/// ```rust, ignore
+/// include_shipstern_parser!("idls/my_program.json");
+/// ```
+///
+/// The input must be Codama JSON, not a raw Anchor IDL. Event and self-CPI
+/// parsing additionally requires the `program-events` feature, which changes
+/// `InstructionParser::Output` from `Instructions` to `ProgramEventOutput`.
+///
+/// A self-CPI event envelope declared in the IDL always wins. The optional
+/// `cpi_event_discriminator` and `cpi_event_payload_offset` arguments are a
+/// fallback for IDLs that declare none, and passing them alongside an
+/// IDL-declared envelope emits a deprecation warning:
+///
+/// ```rust, ignore
+/// include_shipstern_parser!(
+///     "idls/custom_events.json",
+///     cpi_event_discriminator = 0xfe,
+///     cpi_event_payload_offset = 1,
+/// );
+/// ```
+///
+/// `docs/codama-parser-generation.md` is the reference for the envelope: how to
+/// declare one in Codama, the full precedence rules, and the byte layout.
+///
 #[proc_macro]
 pub fn include_shipstern_parser(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as IncludeShipsternParserInput);
@@ -43,28 +75,16 @@ pub fn include_shipstern_parser(input: TokenStream) -> TokenStream {
     }
 }
 
-/// Input for `include_shipstern_parser!`.
 ///
-/// The macro accepts a Codama IDL path, plus optional parser config:
+/// Parsed input of `include_shipstern_parser!`: the IDL path plus the optional
+/// CPI event overrides.
 ///
-/// ```ignore
-/// include_shipstern_parser!(
-///     "../idls/custom_events.json",
-///     cpi_event_discriminator = 0xfe,
-///     cpi_event_payload_offset = 1,
-/// );
-/// ```
+/// The user-facing contract, including how the envelope resolves against an
+/// IDL-declared one, is documented on
+/// [`include_shipstern_parser`]. The overrides are applied to a default
+/// [`ParserConfig`](crate::render::shipstern_parser::ParserConfig) by
+/// [`Self::parser_config`], which `parse::program_envelope` may then overwrite.
 ///
-/// Supported config options:
-/// - `cpi_event_discriminator = 0xfe`: hex bytes that identify self-CPI event instructions.
-///   The string form (`"fe"`) is also accepted for multi-byte discriminators.
-/// - `cpi_event_payload_offset = 1`: byte offset where event payload decoding starts.
-///
-/// When omitted, the parser uses Anchor's default self-CPI event envelope:
-/// an 8-byte Anchor event instruction discriminator, followed by the event
-/// discriminator and payload. Override these options for non-Anchor programs
-/// that wrap events differently, such as Pinocchio programs that emit events
-/// through a custom one-byte self-CPI instruction envelope.
 struct IncludeShipsternParserInput {
     idl_path: LitStr,
     cpi_event_discriminator: Option<HexBytesLiteral>,
@@ -292,7 +312,8 @@ fn cpi_event_args_deprecation() -> proc_macro2::TokenStream {
         const _: () = {
             #[deprecated(
                 note = "the IDL declares a CPI event envelope, so cpi_event_discriminator and \
-                        cpi_event_payload_offset are ignored; these arguments are removed in 0.10"
+                        cpi_event_payload_offset are ignored; prefer declaring the envelope in \
+                        the IDL"
             )]
             const CPI_EVENT_ARGS_IGNORED: () = ();
 

--- a/docs/codama-parser-generation.md
+++ b/docs/codama-parser-generation.md
@@ -1,126 +1,174 @@
-# Generate a Shipstern Parser with Codama
-### How-to generate Shipstern parser with Codama
+# Generate a Shipstern Parser from a Codama IDL
 
-This guide walks you through generating a [Shipstern](https://github.com/solana-rpc/shipstern) Parser using [Codama](https://github.com/abklabs/codama), a tool for rendering Rust SDKs and parser implementations from IDLs.
+Shipstern generates a parser from a [Codama](https://github.com/codama-idl/codama) IDL at
+compile time, through the `include_shipstern_parser!` proc macro. Nothing is written to
+disk and no build script is involved.
 
-Shipstern is a framework for building real-time program data pipelines in Rust. This guide helps you scaffold a parser that can be used in the Shipstern runtime to decode and process Solana program data.
-
-## ✅ Prerequisites
-
-1. **You must have an idl.json file—either an Anchor-generated IDL or a custom one.**
-
-2. **Install [pnpm](https://pnpm.io/) (or use npm/yarn if preferred).**
-
-3. **Initialize a JavaScript Project (for Codegen)**
-
-    From within the parser directory (where the `idl.json` file is located), run:
-
-    ```bash
-    pnpm init
-    ```
-
-## 📦 Installation
-Install the required Codama packages:
-
-```bash
-pnpm install @codama/renderers-shipstern-parser
+```
+Codama JSON ──> include_shipstern_parser! ──> generated parser
+  (complete)        (compile time)       (accounts, instructions, events)
 ```
 
-For the parser generation script, you’ll also need:
+## Quick start
 
-```bash
-pnpm install \
-  @codama/nodes \
-  @codama/nodes-from-anchor \
-  @codama/renderers-core \
-  @codama/visitors-core
-```
+**1. Convert your IDL to Codama JSON.** The macro reads Codama nodes, not a raw Anchor IDL.
 
-## 🛠 Setup
-
-**1. Create a Parser Generation Script**
-
-In the same directory, create a new file called `codama.cjs`:
+One wrinkle makes this more than a one-liner. The macro deserialises through `codama-nodes`
+(pinned to `=0.9.1`), whose serde requires most node fields to be present rather than
+defaulting them, while Codama's JavaScript tooling omits empty and default-valued fields.
+Feeding `JSON.stringify(rootNodeFromAnchor(idl))` straight to the macro fails with
+`missing field 'additionalPrograms'` or `missing field 'accounts'`, depending on which
+collection happens to be empty. Codama also freezes its nodes, so the tree has to be cloned
+before those fields can be added.
 
 ```javascript
-// codama.cjs
+// convert.cjs
+const fs = require("node:fs");
 const path = require("node:path");
-const { rootNode } = require("@codama/nodes");
 const { rootNodeFromAnchor } = require("@codama/nodes-from-anchor");
-const { readJson } = require("@codama/renderers-core");
-const { visit } = require("@codama/visitors-core");
-const { renderVisitor } = require("@codama/renderers-shipstern-parser");
 
-const projectName = "example-parser";
-const idl = readJson(path.join(__dirname, "idl.json"));
+const DEFAULTS = {
+    rootNode: { additionalPrograms: [] },
+    programNode: { accounts: [], definedTypes: [], errors: [], pdas: [], docs: [] },
+    instructionNode: {
+        accounts: [], arguments: [], discriminators: [],
+        docs: [], subInstructions: [], remainingAccounts: [],
+    },
+    accountNode: { discriminators: [], docs: [] },
+    eventNode: { discriminators: [], docs: [] },
+    definedTypeNode: { docs: [] },
+    structFieldTypeNode: { docs: [] },
+    instructionArgumentNode: { docs: [] },
+    instructionAccountNode: { docs: [] },
+    errorNode: { docs: [] },
+};
 
-// Use the appropriate node constructor based on your IDL type:
-const node = rootNodeFromAnchor(idl); // for Anchor/Shank idls
-// const node = rootNode(idl.program); // for Codama idls
+function backfill(node) {
+    if (Array.isArray(node)) return node.forEach(backfill);
+    if (!node || typeof node !== "object") return;
 
-visit(
-    node,
-    renderVisitor({
-        projectFolder: __dirname,
-        projectName,
-    }),
-);
+    for (const [key, value] of Object.entries(DEFAULTS[node.kind] ?? {})) {
+        if (!(key in node)) node[key] = value;
+    }
+
+    Object.values(node).forEach(backfill);
+}
+
+const idl = JSON.parse(fs.readFileSync(path.join(__dirname, "idl.json"), "utf8"));
+
+// Codama freezes its nodes, so round-trip through JSON for a mutable tree.
+const tree = JSON.parse(JSON.stringify(rootNodeFromAnchor(idl)));
+backfill(tree);
+
+fs.writeFileSync(path.join(__dirname, "codama.json"), JSON.stringify(tree, null, 2));
 ```
-
-> 💡 Tip: The `projectName` is going to be used for the cargo crate name of the generated parser
-
-**2. Run the Code Generation Script**
 
 ```bash
-node codama.cjs
+pnpm install @codama/nodes-from-anchor
+node convert.cjs
 ```
 
-Your folder structure should look like this:
+If your IDL is already in complete Codama form, skip this step. `tests/idls/*.json` in this
+repository are all in that shape and make a useful reference.
 
-```bash
-example-parser/
-├── proto/
-│  └── example_parser.proto
-├── src/
-│  ├── generated_parser/  # Shipstern parser logic
-│  │  ├── accounts_parser.rs
-│  │  ├── instructions_parser.rs
-│  │  ├── mod.rs
-│  │  └── proto_helpers.rs
-│  ├── generated_sdk/  # Program sdk client logic
-│  │  ├── accounts/
-│  │  ├── instructions/
-│  │  ├── types/
-│  │  ├── ...
-│  └── lib.rs
-├── build.rs
-├── Cargo.toml
-├── codama.cjs
-└── idl.json
+If your IDL is already in complete Codama form, continue to step 2.
+
+**2. Add the dependencies.**
+
+```toml
+[dependencies]
+borsh = { version = "^1.0.0", features = ["derive"] }
+shipstern-core = { version = "0.10.0" }
+shipstern-parser = { version = "0.10.0" }
+shipstern-proc-macro = { version = "0.10.0" }
 ```
 
-**3. Build and Verify**
-Before building your project, ensure there is a const export of the program address in `generated_sdk/programs.rs`:
+`shipstern-core` and the Borsh `derive` feature are both required: the generated code
+imports `shipstern_core` and derives `BorshDeserialize` / `BorshSerialize` on every type.
+
+To parse events, including self-CPI events, add the `program-events` feature:
+
+```toml
+shipstern-proc-macro = { version = "0.10.0", features = ["program-events"] }
+```
+
+**3. Invoke the macro.** The path is resolved relative to your crate root
+(`CARGO_MANIFEST_DIR`).
 
 ```rust
-pub const DCA_ID: Pubkey = pubkey!("DCA265Vj8a9CEuX1eb1LWRnDT7uK6q1xMipnNyatn23M");
+use shipstern_proc_macro::include_shipstern_parser;
+
+include_shipstern_parser!("path/to/codama.json");
 ```
 
-```bash
-cargo build
+**4. Use the generated module.** It is named after the program, in snake_case, and
+contains `PROGRAM_ID`, `InstructionParser`, `AccountParser`, and the argument and account
+types.
+
+```rust
+let parsed = my_program::InstructionParser.parse(&update).await?;
 ```
 
-If successful, you now have a working parser for Solana account data using Shipstern.
+## What Shipstern reads from the IDL
 
-## 🎉 You’re Done!
-You’ve successfully generated a custom Shipstern parser. It can now be fully integrated into a Shipstern pipeline for parsing and handling account state or instructions updates from your Solana program, or be used with the Shipstern streams gRPC server.
+The macro consumes a subset of the Codama tree. Anything not listed here is ignored, so
+changing it will not affect the generated parser.
 
-## 🧠 Notes
-- Codama enables reproducible parser generation from your program’s IDL. Any time your program updates, just re-run the script.
+| Codama node | Becomes |
+|---|---|
+| `program.name` | the generated module name, in snake_case |
+| `program.publicKey` | `PROGRAM_ID` |
+| `program.instructions[].discriminators` | the instruction dispatch key |
+| `program.instructions[].arguments` | the `*Args` struct |
+| `program.instructions[].accounts` | the `*Accounts` struct |
+| `program.accounts[]` | account types and `AccountParser` |
+| `program.definedTypes[]` | shared types, referenced through `definedTypeLinkNode` |
+| `events[]` | event types, **only** with the `program-events` feature |
 
-- Generated code is idiomatic Rust and integrates directly with shipstern-core.
+Ignored: `pdas` and `docs` are not read at all. `errors` is only normalised on load, where a
+string `"code": "6000"` is coerced to a number; it is never rendered into the parser.
 
-- Parsers are composable and can be used in a source → parser → sink pipeline for high-throughput indexing.
+### Discriminators
+
+Instructions and accounts do not accept the same discriminator kinds.
+
+| Declared on | `constantDiscriminatorNode` | `fieldDiscriminatorNode` | `sizeDiscriminatorNode` |
+|---|---|---|---|
+| instruction | yes, bytes or number value | yes | yes, for dispatch only |
+| account | yes | yes | yes |
+| event | yes, and a chain of two or more declares the CPI envelope | no | no |
+
+A size-discriminated instruction routes on data length like any other, but carries no
+discriminator bytes, so no `*_DISCRIMINATOR` constant is emitted for it. When *every*
+instruction in a program is size-discriminated the whole `impl Instructions` block is
+skipped, and referencing a `*_DISCRIMINATOR` on it will not compile. See
+`tests/proc-macro/tests/size_only_instructions.rs`.
+
+Where several instructions share a discriminator, the generated parser disambiguates by
+account count, trying the variant with the most accounts first. When variants share both
+the discriminator and the account count, supply a `CustomInstructionParser`; see the
+[README](../README.md#handling-discriminator-collisions).
+
+## The `program-events` feature
+
+Event parsing is feature-gated. Without `program-events`, the macro emits no event types
+and no self-CPI handling at all, however the IDL declares its events.
+
+Enabling it also **changes the parser's output type**: `InstructionParser::Output` becomes
+`ProgramEventOutput`, which carries the decoded instruction alongside any events found on
+the transaction's inner instructions, instead of `Instructions` alone.
+
+```rust
+// with program-events
+ProgramEventOutput {
+    instruction: Some(Instructions { .. }),
+    program_events: [Events { .. }],
+}
+```
+
+Because this changes a public type, enabling the feature anywhere in a workspace affects
+every crate that shares the dependency through Cargo's feature unification. Keep crates
+that need different settings in separate workspaces.
 
 ## Self-CPI events (`emit_cpi!`)
 
@@ -159,11 +207,43 @@ The rules:
   tag bytes and the payload offset, or the build fails.
 - An event with a single discriminator declares no envelope. It keeps matching
   at offset 0 and stays reachable from `emit!` log lines.
-- When no event declares an envelope, Anchor's default 8-byte tag is used.
+- When no event declares an envelope and no macro argument supplies one, Anchor's
+  default 8-byte tag is used.
 
 `e445a52e51cb9a1d` is the little-endian serialisation of
 `sha256("anchor:event")[..8]`, whose natural byte order is `1d9acb512ea545e4`.
 Write the wire bytes, not the digest prefix.
+
+### Setting the envelope through Codama
+
+The discriminator chain is the whole configuration surface. A padded envelope, taken from
+`tests/idls/padded_cpi_event_envelope.json`, declares a one-byte tag at offset 0 and the
+event's own two-byte discriminator at offset 4:
+
+```json
+"discriminators": [
+  { "kind": "constantDiscriminatorNode", "offset": 0,
+    "constant": { "kind": "constantValueNode",
+      "type": { "kind": "fixedSizeTypeNode", "size": 1, "type": { "kind": "bytesTypeNode" } },
+      "value": { "kind": "bytesValueNode", "data": "fe", "encoding": "base16" } } },
+  { "kind": "constantDiscriminatorNode", "offset": 4,
+    "constant": { "kind": "constantValueNode",
+      "type": { "kind": "fixedSizeTypeNode", "size": 2, "type": { "kind": "bytesTypeNode" } },
+      "value": { "kind": "bytesValueNode", "data": "a1a2", "encoding": "base16" } } }
+]
+```
+
+That gives a `payload_offset` of 4, so the wire layout is:
+
+```
+offset   0    1              4        6
+        | fe | 00 00 00     | a1 a2 | borsh payload |
+        | tag| three pad    | disc  |               |
+```
+
+`tests/proc-macro-events/tests/padded_cpi_event_envelope.rs` covers both directions: the
+CPI path strips the declared offset of 4 rather than a fixed 8, and the log path still
+matches the same event once its discriminators are rebased.
 
 ### The envelope must not mask an instruction
 
@@ -199,10 +279,38 @@ generated decoders do not.
    discriminator starting at offset 0 is indistinguishable from
    envelope-plus-discriminator, and is treated as the latter.
 
-### Macro arguments are deprecated
+### Legacy macro arguments
 
 `cpi_event_discriminator` and `cpi_event_payload_offset` on
-`include_shipstern_parser!` remain as a fallback for IDLs that declare no
-envelope. When the IDL declares one it wins and the arguments are ignored, with
-a deprecation warning at the call site. Both are removed in 0.10; move the
-envelope into the IDL.
+`include_shipstern_parser!` remain a fallback for IDLs that declare no envelope:
+
+```rust
+include_shipstern_parser!(
+    "path/to/codama.json",
+    cpi_event_discriminator = 0xfe,
+    cpi_event_payload_offset = 1,
+);
+```
+
+Precedence is:
+
+1. an envelope declared in the IDL, which wins whenever present
+2. these arguments, which apply only when the IDL declares none
+3. Anchor's default 8-byte tag, when neither is supplied
+
+When the IDL declares an envelope the arguments are ignored and a deprecation warning
+fires at the call site. No removal version is currently established. Prefer declaring the
+envelope in the IDL, which is the supported path.
+
+## Generating a standalone parser crate
+
+There is also a Codama renderer that writes a complete parser crate to disk, rather than
+expanding a macro in your own crate. It is a separate tool with its own workflow.
+
+> **Note:** the renderer has not been republished under the Shipstern name. The package
+> `@codama/renderers-shipstern-parser` referenced by earlier versions of this guide does
+> not exist on npm. The last published release is `@codama/renderers-vixen-parser` 1.2.8
+> (October 2025). Running it against a small Anchor IDL on the current toolchain emitted
+> only the `generated_sdk/` half and exited non-zero, without producing the
+> `generated_parser/` or `proto/` output this workflow depends on. Whether that is
+> specific to that IDL was not investigated further. Use the proc macro above.

--- a/tests/proc-macro/README.md
+++ b/tests/proc-macro/README.md
@@ -4,7 +4,7 @@ Integration tests for `shipstern-proc-macro`. Each test module loads an IDL via 
 
 | Module | IDL | What it covers |
 |---|---|---|
-| `perpetuals` | `idls/perp_idl.json` | Instruction parsing + schema snapshot |
+| `perpetuals` | `idls/perpetuals.json` | Instruction parsing + schema snapshot |
 | `pump_fun` | `idls/pump_fun.json` | Instruction parsing + schema snapshot |
 | `dynamic_bonding_curve` | `idls/dynamic_bonding_curve.json` | Account parsing + schema snapshot |
 | `order_engine` | `idls/order_engine.json` | IDL with no accounts + schema snapshot |


### PR DESCRIPTION
Four documentation defects, found by following the docs as a new user would.

The most concrete one: following the README on `main` to set up
`include_shipstern_parser!` produces a crate that does not compile.

```
error[E0432]: unresolved import `shipstern_core`
 --> src/lib.rs:2:1
  |
2 | include_shipstern_parser!("idls/my_program.json");
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ use of unresolved module or unlinked crate `shipstern_core`

error[E0433]: cannot find `BorshDeserialize` in `borsh`
```

This is not version skew. The generated code imports `shipstern_core` directly and
`render/rust_types_from_ir.rs` derives `::borsh::BorshDeserialize` /
`::borsh::BorshSerialize` on every generated type, so both `shipstern-core` and
borsh's `derive` feature are required. Neither was listed.

A third requirement was undocumented anywhere. Event and self-CPI parsing is gated
behind `program-events` (`crates/proc-macro/src/render/shipstern_parser.rs:70`,
`cfg!(feature = "program-events") && !events.is_empty()`). Without it the macro
emits no event types, so the entire CPI section of
`docs/codama-parser-generation.md` described behaviour a reader following the
README could not reach. Enabling it also changes `InstructionParser::Output` from
`Instructions` to `ProgramEventOutput`, which propagates through Cargo feature
unification. That is why `tests/proc-macro-events` sits outside the main
workspace, and it was not written down.

Counting event-related items in `cargo expand` for a fixture IDL with one event:

| dependency set | result |
|---|---|
| README as written | `cargo build` exit 101, `E0432` + `E0433` |
| `crates/proc-macro/README.md` as written | exit 101, `E0432` |
| plus `shipstern-core` and borsh `derive` | exit 0, 0 event items |
| plus `program-events` | exit 0, 51 event items |

The doc had a second problem. Its primary workflow told users to run
`pnpm install @codama/renderers-shipstern-parser`, which returns
`{"error":"Not found"}`. An npm search for "shipstern" returns zero packages. The
rename in #279 updated the doc text, but nothing was published under the new name,
so the first step of the documented path could not be run at all.

## What changed

`docs/codama-parser-generation.md` now leads with `include_shipstern_parser!` and
carries a working Anchor to Codama conversion. That step needs more than
`JSON.stringify(rootNodeFromAnchor(idl))`, for two reasons found by trying it:
`codama-nodes` (pinned `=0.9.1`) requires most node fields to be present while
Codama's JS omits empty ones, and Codama freezes its nodes so they cannot be
backfilled in place. The script clones through JSON, backfills the empty
collections by node kind, and its output compiles and parses.

A new section, "What Shipstern reads from the IDL", lists the nodes the macro
consumes and what it ignores (`pdas` and `docs` are read nowhere, `errors` is only
normalised on load so a string `"code": "6000"` becomes a number). It also records
that instructions and accounts accept different discriminator kinds, and that a
size-discriminated instruction routes normally but emits no `*_DISCRIMINATOR`
constant, per `tests/proc-macro/tests/size_only_instructions.rs`.

Both READMEs gain `shipstern-core`, borsh's `derive` feature, and the
`program-events` note. The rustdoc for `include_shipstern_parser` moves off a
private struct, where it never rendered in `cargo doc`, onto the public macro.

The 0.9.0 Deprecated entry claimed `cpi_event_discriminator` and
`cpi_event_payload_offset` were removed in 0.10. They are still parsed and
honoured as the fallback for IDLs that declare no CPI event envelope
(`crates/proc-macro/src/lib.rs:106,109`), and 0.10.0 shipped without removing
them. Corrected in place, and the same claim is removed from the `#[deprecated]`
note and the doc. No replacement version is claimed.

`tests/proc-macro/README.md` referenced `idls/perp_idl.json`, which does not
exist. The test loads `idls/perpetuals.json`.

## Verification

Every documented claim was run, not just read.

- The dependency snippet builds in a fresh crate outside the repo against the
  published `0.10.0` crates, no path dependencies.
- The Anchor IDL in the guide converts and parses to
  `DoThing { payer: KeyBytes(..), amount: 99 }`.
- The padded envelope diagram, built byte for byte from the figure (`fe`, three
  pad bytes, `a1a2`, then the payload), parses to `AlphaEvent { amount: 987654321 }`.
- An account update parses to `Vault { amount: 424242 }`.
- `cargo doc` now renders the macro page with its docblock, previously zero.

`cargo fmt`, `cargo clippy -Dwarnings`, `cargo deny`, 361 workspace tests and 45
`proc-macro-events` tests all pass.

## Alternatives ruled out

Keeping the standalone code generation path as primary does not work. Running
`@codama/renderers-vixen-parser` 1.2.8, the last published release, against a
small Anchor IDL emitted only the `generated_sdk/` half and exited non-zero,
without producing the `generated_parser/` or `proto/` output the workflow needs.
Whether that is specific to that IDL was not chased down. The section stays as a
short note rather than a supported path.

Naming 0.11 as the removal version for the deprecated arguments was considered and
dropped. There is no agreement on record for that, so the docs state current
behaviour and no version.

## Notes

`docs/codama-parser-generation.md` now contains version pins, so it belongs
alongside the two README files in future release bumps (see #314, #316).

The conversion friction above is upstream, not a parser bug. Codama's JS
serializer and its Rust `codama-nodes` deserializer disagree on whether empty
fields may be omitted. `codama-idl/codama-rs#108` is the relevant upstream work.

Two things found while doing this, both out of scope here:

- `shipstern-jetstream-source` is stuck at `0.9.0` on crates.io while every other
  workspace crate published `0.10.0`. `Cargo.toml:106` pins `jetstreamer-firehose`
  by git, and cargo refuses to publish a crate with a git dependency (`all
  dependencies must have a version requirement specified when publishing`).
  Introduced by #315.
- #316 did not update `tests/proc-macro-events/Cargo.lock`, so running that
  workspace's tests rewrites 13 version entries from `0.9.0` to `0.10.0`.
